### PR TITLE
chore: address remaining PR review nits

### DIFF
--- a/swarm/runtime/stepwise/routing/driver.py
+++ b/swarm/runtime/stepwise/routing/driver.py
@@ -339,25 +339,17 @@ def _step_result_to_dict(step_result: Any) -> Dict[str, Any]:
 
     # Extract common attributes from StepResult or similar objects
     result: Dict[str, Any] = {}
-
-    # Core routing fields
-    if hasattr(step_result, "status"):
-        result["status"] = step_result.status
-    if hasattr(step_result, "output"):
-        result["output"] = step_result.output
-    if hasattr(step_result, "error"):
-        result["error"] = step_result.error
-    if hasattr(step_result, "duration_ms"):
-        result["duration_ms"] = step_result.duration_ms
-    if hasattr(step_result, "step_id"):
-        result["step_id"] = step_result.step_id
-    if hasattr(step_result, "artifacts"):
-        result["artifacts"] = step_result.artifacts
-
-    # Microloop-specific fields (from receipts or step output)
-    if hasattr(step_result, "can_further_iteration_help"):
-        result["can_further_iteration_help"] = step_result.can_further_iteration_help
-
+    for attr in (
+        "status",
+        "output",
+        "error",
+        "duration_ms",
+        "step_id",
+        "artifacts",
+        "can_further_iteration_help",
+    ):
+        if hasattr(step_result, attr):
+            result[attr] = getattr(step_result, attr)
     return result
 
 

--- a/swarm/runtime/types/__init__.py
+++ b/swarm/runtime/types/__init__.py
@@ -1489,7 +1489,7 @@ class RunPlanSpec:
     """
 
     flow_sequence: List[str] = field(
-        default_factory=lambda: _get_default_flow_sequence()  # From registry, includes review
+        default_factory=_get_default_flow_sequence  # From registry, includes review
     )
     macro_policy: MacroPolicy = field(default_factory=MacroPolicy.default)
     human_policy: HumanPolicy = field(default_factory=HumanPolicy.autopilot)

--- a/tests/test_flow_order_guardrail.py
+++ b/tests/test_flow_order_guardrail.py
@@ -380,13 +380,12 @@ flows = [
     "deploy", "wisdom"
 ]
 '''
-        # This won't be detected by current patterns since they're single-line
-        # That's acceptable - the main risk is copy-paste of inline lists
-        # Multiline lists are less common and easier to spot in review
-        _violations = _find_violations(code, Path("test.py"))  # noqa: F841
-        # We don't require detection of multiline lists, just document behavior
-        # The assignment above documents that we tried the pattern
-        assert True  # Pattern behavior is acceptable
+        # This won't be detected by current patterns since they're single-line.
+        # That's acceptable - the main risk is copy-paste of inline lists.
+        # Multiline lists are less common and easier to spot in review.
+        _find_violations(code, Path("test.py"))
+        # We don't require detection of multiline lists, just document behavior.
+        assert True
 
 
 class TestFlowOrderGuardrailExclusions:

--- a/tests/test_routing_driver_fixes.py
+++ b/tests/test_routing_driver_fixes.py
@@ -19,8 +19,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
-import pytest
-
 from swarm.config.flow_registry import StepDefinition, StepRouting
 from swarm.runtime.stepwise.routing.driver import (
     RoutingOutcome,


### PR DESCRIPTION
## Summary
Follow-up cleanup from PR #5 review feedback:

- Drop unused assignment + `# noqa` in test_flow_order_guardrail.py
- Remove unused `pytest` import in test_routing_driver_fixes.py
- Remove lambda wrapper in `default_factory` (types/__init__.py)
- Refactor `_step_result_to_dict` to use attribute loop

## Test plan
- [x] `uv run swarm/tools/validate_swarm.py` ✅
- [x] `uv run pytest tests/test_routing_driver_fixes.py -q` ✅ (14 passed)
- [x] `uv run pytest tests/test_route_step_navigator.py -q` ✅ (11 passed)
- [x] `uv run pytest tests/test_phase6_verification.py -q` ✅ (8 passed)
- [x] `uv run pytest tests/test_flow_order_guardrail.py -q` ✅ (19 passed)