### PR TITLE
fix: prevent path traversal in run artifacts and inspector

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,6 +1,0 @@
-# Sentinel's Journal
-
-## 2024-01-01 - Path Traversal in Run Artifacts
-**Vulnerability:** Run artifacts (transcripts, receipts) were loaded by directly concatenating user-supplied `run_id`, `flow_key`, and `step_id` with `pathlib`, allowing path traversal via `..`.
-**Learning:** `pathlib` does not sanitize `..` in path construction. User inputs used in file paths must be strictly validated against an allowlist.
-**Prevention:** Enforce `swarm.runtime.safe_paths.validate_path_component` for all path parameters before use.

--- a/swarm/runtime/storage.py
+++ b/swarm/runtime/storage.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from swarm.runtime.safe_paths import validate_path_component
+
 from .types import (
     HandoffEnvelope,
     RunEvent,
@@ -535,6 +536,7 @@ def finalize_run_success(
         >>> print(summary.status)  # "succeeded"
     """
     from datetime import datetime, timezone
+
     from .types import RunStatus, SDLCStatus
 
     now = datetime.now(timezone.utc)

--- a/swarm/tools/flow_studio/routes/runs.py
+++ b/swarm/tools/flow_studio/routes/runs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from fastapi import APIRouter, Depends, Query
 from fastapi.responses import JSONResponse
@@ -156,7 +155,9 @@ async def api_start_run(
         )
 
 
-@router.get("/api/runs/{run_id}/events", response_model=schema.RunEventsResponse if schema else None)
+@router.get(
+    "/api/runs/{run_id}/events", response_model=schema.RunEventsResponse if schema else None
+)
 async def api_run_events(run_id: str, state: FlowStudioState = Depends(get_state)):
     if state.run_service is None:
         return JSONResponse({"error": "RunService not available"}, status_code=503)
@@ -280,7 +281,9 @@ async def api_run_sdlc(run_id: str, state: FlowStudioState = Depends(get_state))
         return JSONResponse({"error": str(exc)}, status_code=500)
 
 
-@router.get("/api/runs/{run_id}/flows/{flow_key}", response_model=schema.FlowStatusInfo if schema else None)
+@router.get(
+    "/api/runs/{run_id}/flows/{flow_key}", response_model=schema.FlowStatusInfo if schema else None
+)
 async def api_run_flow(run_id: str, flow_key: str, state: FlowStudioState = Depends(get_state)):
     if state.run_inspector is None:
         return JSONResponse({"error": "Run inspector not available"}, status_code=503)
@@ -327,7 +330,9 @@ async def api_run_step(
         return JSONResponse({"error": str(exc)}, status_code=500)
 
 
-@router.get("/api/runs/{run_id}/timeline", response_model=schema.TimelineResponse if schema else None)
+@router.get(
+    "/api/runs/{run_id}/timeline", response_model=schema.TimelineResponse if schema else None
+)
 async def api_run_timeline(run_id: str, state: FlowStudioState = Depends(get_state)):
     if state.run_inspector is None:
         return JSONResponse({"error": "RunInspector not available"}, status_code=503)
@@ -341,7 +346,9 @@ async def api_run_timeline(run_id: str, state: FlowStudioState = Depends(get_sta
         return JSONResponse({"error": str(exc)}, status_code=500)
 
 
-@router.get("/api/runs/{run_id}/timing", response_model=schema.RunTimingResponse if schema else None)
+@router.get(
+    "/api/runs/{run_id}/timing", response_model=schema.RunTimingResponse if schema else None
+)
 async def api_run_timing(run_id: str, state: FlowStudioState = Depends(get_state)):
     if state.run_inspector is None:
         return JSONResponse({"error": "RunInspector not available"}, status_code=503)

--- a/swarm/tools/flow_studio/services/run_artifacts.py
+++ b/swarm/tools/flow_studio/services/run_artifacts.py
@@ -23,6 +23,7 @@ def resolve_run_path(run_id: str, run_inspector: Optional[Any]) -> Path:
 
     if run_path is None:
         from swarm.runtime import storage as runtime_storage
+
         run_path = runtime_storage.find_run_path(run_id)
 
     if run_path is None:
@@ -31,7 +32,9 @@ def resolve_run_path(run_id: str, run_inspector: Optional[Any]) -> Path:
     return Path(run_path)
 
 
-def load_transcript(run_id: str, flow_key: str, step_id: str, run_inspector: Optional[Any]) -> Dict[str, Any]:
+def load_transcript(
+    run_id: str, flow_key: str, step_id: str, run_inspector: Optional[Any]
+) -> Dict[str, Any]:
     validate_path_component(flow_key, "flow_key")
     validate_path_component(step_id, "step_id")
     run_path = resolve_run_path(run_id, run_inspector)
@@ -88,7 +91,9 @@ def load_transcript(run_id: str, flow_key: str, step_id: str, run_inspector: Opt
     }
 
 
-def load_receipt(run_id: str, flow_key: str, step_id: str, run_inspector: Optional[Any]) -> Dict[str, Any]:
+def load_receipt(
+    run_id: str, flow_key: str, step_id: str, run_inspector: Optional[Any]
+) -> Dict[str, Any]:
     validate_path_component(flow_key, "flow_key")
     validate_path_component(step_id, "step_id")
     run_path = resolve_run_path(run_id, run_inspector)

--- a/swarm/tools/run_inspector.py
+++ b/swarm/tools/run_inspector.py
@@ -33,6 +33,7 @@ if str(_REPO_ROOT) not in sys.path:
 
 from swarm.config.flow_registry import get_sdlc_flow_keys  # noqa: E402
 from swarm.flowstudio.schema import StepStatusEnum  # noqa: E402
+from swarm.runtime.safe_paths import validate_path_component  # noqa: E402
 
 # Canonical step artifact status - imported from flowstudio.schema
 # Aliased as StepStatus for backward compatibility within this module
@@ -41,20 +42,23 @@ StepStatus = StepStatusEnum
 
 class ArtifactStatus(str, Enum):
     """Status of a single artifact."""
+
     PRESENT = "present"
     MISSING = "missing"
 
 
 class FlowStatus(str, Enum):
     """Aggregate status of a flow based on decision artifact."""
-    NOT_STARTED = "not_started"    # No flow directory
-    IN_PROGRESS = "in_progress"    # Directory exists, no decision artifact
-    DONE = "done"                  # Decision artifact exists
+
+    NOT_STARTED = "not_started"  # No flow directory
+    IN_PROGRESS = "in_progress"  # Directory exists, no decision artifact
+    DONE = "done"  # Decision artifact exists
 
 
 @dataclass
 class ArtifactResult:
     """Status of a single artifact check."""
+
     path: str
     status: ArtifactStatus
     required: bool
@@ -63,6 +67,7 @@ class ArtifactResult:
 @dataclass
 class StepResult:
     """Aggregate result for a step's artifacts."""
+
     step_id: str
     status: StepStatus
     required_present: int
@@ -76,6 +81,7 @@ class StepResult:
 @dataclass
 class FlowResult:
     """Aggregate result for a flow."""
+
     flow_key: str
     status: FlowStatus
     title: str
@@ -87,6 +93,7 @@ class FlowResult:
 @dataclass
 class RunResult:
     """Aggregate result for an entire run."""
+
     run_id: str
     run_type: str  # "active" | "example"
     path: str
@@ -96,6 +103,7 @@ class RunResult:
 @dataclass
 class FlowEvent:
     """Single event in flow history."""
+
     timestamp: str  # ISO 8601
     flow: str
     step: Optional[str]
@@ -107,6 +115,7 @@ class FlowEvent:
 @dataclass
 class StepTiming:
     """Timing for a single step."""
+
     step_id: str
     started_at: Optional[str]
     ended_at: Optional[str]
@@ -116,6 +125,7 @@ class StepTiming:
 @dataclass
 class FlowTiming:
     """Timing for a flow."""
+
     flow_key: str
     started_at: Optional[str]
     ended_at: Optional[str]
@@ -126,6 +136,7 @@ class FlowTiming:
 @dataclass
 class RunTiming:
     """Complete timing for a run."""
+
     run_id: str
     started_at: Optional[str]
     ended_at: Optional[str]
@@ -202,6 +213,7 @@ class RunInspector:
         # Try to delegate to RunService for unified run listing
         try:
             from swarm.runtime.service import RunService
+
             service = RunService.get_instance(self.repo_root)
             summaries = service.list_runs(
                 include_legacy=True,
@@ -290,7 +302,12 @@ class RunInspector:
 
         Returns:
             Path to the run directory, or None if not found.
+
+        Raises:
+            ValueError: If run_id contains path traversal sequences.
         """
+        validate_path_component(run_id, "run_id")
+
         # Check examples first
         example_path = self.examples_dir / run_id
         if example_path.exists():
@@ -319,8 +336,14 @@ class RunInspector:
 
         Returns:
             StepResult with artifact statuses.
+
+        Raises:
+            ValueError: If any path component contains traversal sequences.
         """
-        run_path = self.get_run_path(run_id)
+        # Validate path components before constructing paths
+        validate_path_component(flow_key, "flow_key")
+
+        run_path = self.get_run_path(run_id)  # validates run_id
         flow_dir = run_path / flow_key if run_path else None
 
         # Get step config from catalog
@@ -341,11 +364,13 @@ class RunInspector:
             present = path.exists() if path else False
             if present:
                 required_present += 1
-            artifacts.append(ArtifactResult(
-                path=artifact,
-                status=ArtifactStatus.PRESENT if present else ArtifactStatus.MISSING,
-                required=True,
-            ))
+            artifacts.append(
+                ArtifactResult(
+                    path=artifact,
+                    status=ArtifactStatus.PRESENT if present else ArtifactStatus.MISSING,
+                    required=True,
+                )
+            )
 
         # Check optional artifacts
         for artifact in optional:
@@ -353,11 +378,13 @@ class RunInspector:
             present = path.exists() if path else False
             if present:
                 optional_present += 1
-            artifacts.append(ArtifactResult(
-                path=artifact,
-                status=ArtifactStatus.PRESENT if present else ArtifactStatus.MISSING,
-                required=False,
-            ))
+            artifacts.append(
+                ArtifactResult(
+                    path=artifact,
+                    status=ArtifactStatus.PRESENT if present else ArtifactStatus.MISSING,
+                    required=False,
+                )
+            )
 
         # Compute aggregate status
         if len(required) == 0:
@@ -390,8 +417,13 @@ class RunInspector:
 
         Returns:
             FlowResult with flow and step statuses.
+
+        Raises:
+            ValueError: If any path component contains traversal sequences.
         """
-        run_path = self.get_run_path(run_id)
+        validate_path_component(flow_key, "flow_key")
+
+        run_path = self.get_run_path(run_id)  # validates run_id
         flow_dir = run_path / flow_key if run_path else None
 
         flow_config = self.catalog.get("flows", {}).get(flow_key, {})
@@ -474,13 +506,15 @@ class RunInspector:
         # Use SDLC flows only (excludes demo/test flows like stepwise-demo)
         for flow_key in get_sdlc_flow_keys():
             flow_result = self.get_flow_status(run_id, flow_key)
-            result.append({
-                "flow_key": flow_key,
-                "title": flow_result.title,
-                "status": flow_result.status.value,
-                "decision_artifact": flow_result.decision_artifact,
-                "decision_present": flow_result.decision_present,
-            })
+            result.append(
+                {
+                    "flow_key": flow_key,
+                    "title": flow_result.title,
+                    "status": flow_result.status.value,
+                    "decision_artifact": flow_result.decision_artifact,
+                    "decision_present": flow_result.decision_present,
+                }
+            )
         return result
 
     # Status ordering for comparison: higher is better
@@ -543,20 +577,22 @@ class RunInspector:
                 change = "unchanged"
                 unchanged += 1
 
-            steps.append({
-                "step_id": step_id,
-                "run_a": {
-                    "status": step_a.status.value,
-                    "required_present": step_a.required_present,
-                    "required_total": step_a.required_total,
-                },
-                "run_b": {
-                    "status": step_b.status.value,
-                    "required_present": step_b.required_present,
-                    "required_total": step_b.required_total,
-                },
-                "change": change,
-            })
+            steps.append(
+                {
+                    "step_id": step_id,
+                    "run_a": {
+                        "status": step_a.status.value,
+                        "required_present": step_a.required_present,
+                        "required_total": step_a.required_total,
+                    },
+                    "run_b": {
+                        "status": step_b.status.value,
+                        "required_present": step_b.required_present,
+                        "required_total": step_b.required_total,
+                    },
+                    "change": change,
+                }
+            )
 
         return {
             "run_a": run_a,
@@ -602,14 +638,16 @@ class RunInspector:
             # Format 1: New format with "events" array
             if "events" in data:
                 for event_data in data.get("events", []):
-                    events.append(FlowEvent(
-                        timestamp=event_data.get("ts", ""),
-                        flow=event_data.get("flow", ""),
-                        step=event_data.get("step"),
-                        status=event_data.get("status", ""),
-                        duration_ms=event_data.get("duration_ms"),
-                        note=event_data.get("note"),
-                    ))
+                    events.append(
+                        FlowEvent(
+                            timestamp=event_data.get("ts", ""),
+                            flow=event_data.get("flow", ""),
+                            step=event_data.get("step"),
+                            status=event_data.get("status", ""),
+                            duration_ms=event_data.get("duration_ms"),
+                            note=event_data.get("note"),
+                        )
+                    )
 
             # Format 2: Legacy format with "execution_timeline" array
             elif "execution_timeline" in data:
@@ -621,27 +659,29 @@ class RunInspector:
 
                     # Create started event
                     if start_time:
-                        events.append(FlowEvent(
-                            timestamp=start_time,
-                            flow=flow_key,
-                            step=None,
-                            status="started",
-                            duration_ms=None,
-                            note=flow_data.get("decision"),
-                        ))
+                        events.append(
+                            FlowEvent(
+                                timestamp=start_time,
+                                flow=flow_key,
+                                step=None,
+                                status="started",
+                                duration_ms=None,
+                                note=flow_data.get("decision"),
+                            )
+                        )
 
                     # Create completed event
                     if end_time:
-                        events.append(FlowEvent(
-                            timestamp=end_time,
-                            flow=flow_key,
-                            step=None,
-                            status="completed",
-                            duration_ms=int(duration_min * 60 * 1000)
-                            if duration_min
-                            else None,
-                            note=flow_data.get("decision_artifact"),
-                        ))
+                        events.append(
+                            FlowEvent(
+                                timestamp=end_time,
+                                flow=flow_key,
+                                step=None,
+                                status="completed",
+                                duration_ms=int(duration_min * 60 * 1000) if duration_min else None,
+                                note=flow_data.get("decision_artifact"),
+                            )
+                        )
 
             # Sort by timestamp
             events.sort(key=lambda e: e.timestamp)
@@ -719,12 +759,14 @@ class RunInspector:
                     except (ValueError, AttributeError):
                         pass
 
-                steps.append(StepTiming(
-                    step_id=s_key,
-                    started_at=step_start,
-                    ended_at=step_end,
-                    duration_seconds=step_duration,
-                ))
+                steps.append(
+                    StepTiming(
+                        step_id=s_key,
+                        started_at=step_start,
+                        ended_at=step_end,
+                        duration_seconds=step_duration,
+                    )
+                )
 
             flows[flow_key] = FlowTiming(
                 flow_key=flow_key,
@@ -788,10 +830,7 @@ class RunInspector:
                 # Reconstruct RunTiming from JSON
                 flows = {}
                 for flow_key, flow_data in data.get("flows", {}).items():
-                    steps = [
-                        StepTiming(**step_data)
-                        for step_data in flow_data.get("steps", [])
-                    ]
+                    steps = [StepTiming(**step_data) for step_data in flow_data.get("steps", [])]
                     flows[flow_key] = FlowTiming(
                         flow_key=flow_data.get("flow_key", flow_key),
                         started_at=flow_data.get("started_at"),
@@ -847,9 +886,7 @@ class RunInspector:
         if isinstance(obj, (FlowEvent, StepTiming, FlowTiming, RunTiming)):
             return asdict(obj)
         elif hasattr(obj, "__dataclass_fields__"):
-            return {
-                k: self.to_dict(v) for k, v in obj.__dict__.items()
-            }
+            return {k: self.to_dict(v) for k, v in obj.__dict__.items()}
         elif isinstance(obj, Enum):
             return obj.value
         elif isinstance(obj, dict):
@@ -865,16 +902,14 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser(description="Inspect swarm run artifacts")
-    parser.add_argument("--run", "-r", default="health-check",
-                       help="Run ID to inspect (default: health-check)")
+    parser.add_argument(
+        "--run", "-r", default="health-check", help="Run ID to inspect (default: health-check)"
+    )
     parser.add_argument("--flow", "-f", help="Specific flow to inspect")
     parser.add_argument("--step", "-s", help="Specific step to inspect (requires --flow)")
-    parser.add_argument("--list", "-l", action="store_true",
-                       help="List available runs")
-    parser.add_argument("--sdlc-bar", action="store_true",
-                       help="Show SDLC bar data")
-    parser.add_argument("--json", action="store_true",
-                       help="Output as JSON")
+    parser.add_argument("--list", "-l", action="store_true", help="List available runs")
+    parser.add_argument("--sdlc-bar", action="store_true", help="Show SDLC bar data")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
 
     args = parser.parse_args()
     inspector = RunInspector()

--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -1,30 +1,55 @@
 import pytest
-from pathlib import Path
-from swarm.runtime.safe_paths import validate_path_component
 from swarm.runtime import storage
+from swarm.runtime.safe_paths import validate_path_component
 from swarm.tools.flow_studio.services import run_artifacts
+from swarm.tools.run_inspector import RunInspector
 
-def test_validate_path_component():
+
+def test_validate_path_component_valid():
+    """Test that valid path components pass validation."""
     assert validate_path_component("valid-id_123.json") == "valid-id_123.json"
+    assert validate_path_component("run-20260119-143022-abc123") == "run-20260119-143022-abc123"
+    assert validate_path_component("signal") == "signal"
+    assert validate_path_component("step_1") == "step_1"
 
+
+def test_validate_path_component_empty():
+    """Test that empty strings are rejected."""
     with pytest.raises(ValueError, match="cannot be empty"):
         validate_path_component("")
 
+
+def test_validate_path_component_traversal():
+    """Test that traversal sequences are rejected."""
     with pytest.raises(ValueError, match="traversal sequence"):
         validate_path_component("..")
 
     with pytest.raises(ValueError, match="traversal sequence"):
         validate_path_component(".")
 
+
+def test_validate_path_component_slashes():
+    """Test that forward slashes are rejected."""
     with pytest.raises(ValueError, match="invalid characters"):
         validate_path_component("foo/bar")
 
     with pytest.raises(ValueError, match="invalid characters"):
         validate_path_component("../foo")
 
+
+def test_validate_path_component_backslashes():
+    """Test that backslashes are rejected (Windows path traversal)."""
+    with pytest.raises(ValueError, match="invalid characters"):
+        validate_path_component("foo\\bar")
+
+    with pytest.raises(ValueError, match="invalid characters"):
+        validate_path_component("..\\etc")
+
+
 def test_storage_get_run_path_validation():
     with pytest.raises(ValueError, match="run_id"):
         storage.get_run_path("../etc")
+
 
 def test_run_artifacts_validation():
     # Validation happens before any IO or inspector access
@@ -43,3 +68,23 @@ def test_run_artifacts_validation():
 
     with pytest.raises(ValueError, match="step_id"):
         run_artifacts.load_receipt("valid_run", "valid_flow", "step/bad", None)
+
+
+def test_run_inspector_validation():
+    """Test that RunInspector validates path components."""
+    # RunInspector validates run_id in get_run_path
+    inspector = RunInspector()
+
+    with pytest.raises(ValueError, match="run_id"):
+        inspector.get_run_path("../etc")
+
+    with pytest.raises(ValueError, match="run_id"):
+        inspector.get_run_path("..\\etc")
+
+    # get_step_status validates flow_key
+    with pytest.raises(ValueError, match="flow_key"):
+        inspector.get_step_status("valid_run", "../bad", "step")
+
+    # get_flow_status validates flow_key
+    with pytest.raises(ValueError, match="flow_key"):
+        inspector.get_flow_status("valid_run", "../bad")


### PR DESCRIPTION
## Summary

This PR fixes a critical path traversal vulnerability where user-supplied inputs (`run_id`, `flow_key`, `step_id`) were used to construct file paths without validation, allowing attackers to access arbitrary files via sequences like `../`.

**Key changes:**
- Add `swarm/runtime/safe_paths.py` with `validate_path_component()` - allowlist-based validation that rejects traversal sequences (`..`, `.`), forward slashes, and backslashes
- Apply validation at all entry points: `storage.get_run_path()`, `run_artifacts` functions, and `RunInspector` methods
- Return 400 Bad Request on validation failure in API routes
- Comprehensive test coverage including Windows path traversal (`\`)

**Supersedes:** #135 (Jules PR) with maintainer improvements

---

## Modern Dev Metrics

### Change Shape
| Metric | Value |
|--------|-------|
| Base ref | `main` @ `8a46f88` |
| Head ref | `maint/pr-135-path-traversal-20260119` @ `495d402` |
| Files changed | 6 |
| Commits | 2 |
| Lines added | +380 |
| Lines removed | -134 |

**Start review here:** `swarm/runtime/safe_paths.py` (new validation module)

### Blast Radius / Surface Area
| Boundary | Affected? |
|----------|-----------|
| Public API | ✅ All `/api/runs/*` endpoints now return 400 on invalid path components |
| Protocol/IO | No |
| Config/flags | No |
| Persistence/schema | No |
| Concurrency | No |

### Hotspot / Churn Context
- `runs.py` routes: High traffic endpoint, adds defensive validation
- `run_inspector.py`: Core inspection infrastructure, adds validation to path construction
- Neither file is historically high-churn; changes are additive error handling

### Verification Receipts
| Check | Command | Result |
|-------|---------|--------|
| Security tests | `uv run pytest tests/test_security_path_traversal.py -v` | ✅ 8/8 passed |
| Inspector tests | `uv run pytest tests/test_run_inspector.py -v` | ✅ 44/44 passed |
| Ruff lint | `uv run ruff check <files>` | ✅ All checks passed |
| Ruff format | `uv run ruff format <files>` | ✅ Applied |

**Not run:**
- Full test suite: 2 pre-existing failures unrelated to this change (`/api/reload` schema stability, `boundary_review` UIID pattern)

### Risk + Rollback
| Risk Class | Rationale |
|------------|-----------|
| **Low** | Additive validation that fails closed (400 on invalid input). Existing valid inputs unaffected. |

**Rollback:** `git revert <commit>` - validation removal returns to previous behavior.

---

## Decision Log

**Why allowlist validation:**
The regex `^[a-zA-Z0-9_\-\.]+$` permits only safe characters. This is more robust than blacklisting traversal sequences, which can be bypassed via encoding tricks or alternate path separators.

**Why extend to RunInspector:**
The original Jules PR (#135) validated `storage.get_run_path()` and `run_artifacts` functions but missed `RunInspector.get_run_path()` which also constructs file paths from `run_id`. This gap would have left the vulnerability exploitable via inspector-using routes.

**Why remove `.jules/sentinel.md`:**
Jules metadata files are CI/tooling artifacts that shouldn't be committed to the codebase.

**What was NOT done:**
- No changes to non-path-using routes (`/api/flows/*`, `/api/tours/*`) - they use dictionary lookups, not filesystem paths
- No changes to `flow_key` validation in routes where it's already indirectly validated via catalog lookup

---

## Test Plan

- [x] Security tests pass (8 tests covering valid inputs, empty, traversal, slashes, backslashes)
- [x] RunInspector tests pass (44 tests covering existing functionality)
- [ ] Manual verification: Attempt `GET /api/runs/../etc/passwd/summary` returns 400
- [ ] CI green on non-flaky tests