### PR TITLE
perf: add thread-safe caching for terminal run summaries

### DIFF
--- a/swarm/runtime/service.py
+++ b/swarm/runtime/service.py
@@ -180,14 +180,18 @@ class RunService:
         # Try storage first (works for all backends)
         summary = storage.read_summary(run_id)
         if summary:
-            # Cache if terminal state (thread-safe write)
+            # Cache if terminal state (thread-safe write with re-check)
+            # Re-check under lock to avoid stale cache insertion after invalidation
             if summary.status in (
                 RunStatus.SUCCEEDED,
                 RunStatus.FAILED,
                 RunStatus.CANCELED,
             ):
                 with self._cache_lock:
-                    self._summary_cache[run_id] = summary
+                    # Only insert if not already present (could have been
+                    # invalidated between storage read and this point)
+                    if run_id not in self._summary_cache:
+                        self._summary_cache[run_id] = summary
             return summary
 
         # Fall back to querying backends
@@ -382,10 +386,12 @@ class RunService:
         if not summary:
             return False
 
-        tags = [t for t in summary.tags if t != tag]
-        storage.update_summary(run_id, {"tags": tags})
-        # Invalidate cache (thread-safe)
-        self._invalidate_cache(run_id)
+        # Only update if tag is actually present
+        if tag in summary.tags:
+            tags = [t for t in summary.tags if t != tag]
+            storage.update_summary(run_id, {"tags": tags})
+            # Invalidate cache (thread-safe)
+            self._invalidate_cache(run_id)
         return True
 
     def list_exemplars(self) -> List[RunSummary]:

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -363,9 +363,9 @@ class TestRunService:
 class TestRunServiceCaching:
     """Test RunService caching behavior for terminal runs.
 
-    Note: These tests write to the real swarm/runs/ directory because
-    RunService uses storage functions with default parameters that can't
-    be easily monkeypatched. Each test cleans up after itself.
+    Note: These tests monkeypatch storage.RUNS_DIR to use tmp_path, ensuring
+    test isolation. The monkeypatched RUNS_DIR is used by storage functions
+    when called without explicit runs_dir parameter.
     """
 
     def test_cache_hit_for_terminal_run(self, tmp_path, monkeypatch):
@@ -517,6 +517,86 @@ class TestRunServiceCaching:
             # Next get_run should see updated tags
             result = service.get_run(run_id)
             assert "important" in result.tags
+        finally:
+            # Cleanup
+            import shutil
+            run_path = storage.get_run_path(run_id)
+            if run_path.exists():
+                shutil.rmtree(run_path)
+            RunService.reset()
+
+    def test_cache_invalidation_on_remove_tag(self, tmp_path, monkeypatch):
+        """Cache should be invalidated when removing a tag."""
+        monkeypatch.setattr(storage, "RUNS_DIR", tmp_path)
+
+        RunService.reset()
+        service = RunService.get_instance(tmp_path)
+
+        run_id = "cache-remove-tag-test"
+        now = datetime.now(timezone.utc)
+        summary = RunSummary(
+            id=run_id,
+            spec=RunSpec(flow_keys=["signal"], backend="claude-harness", initiator="test"),
+            status=RunStatus.FAILED,
+            sdlc_status=SDLCStatus.ERROR,
+            created_at=now,
+            updated_at=now,
+            tags=["to-remove", "keep"],
+        )
+        storage.write_summary(run_id, summary)
+
+        try:
+            # Populate cache
+            service.get_run(run_id)
+            assert run_id in service._summary_cache
+
+            # Remove tag (should invalidate cache)
+            service.remove_tag(run_id, "to-remove")
+            assert run_id not in service._summary_cache
+
+            # Next get_run should see updated tags
+            result = service.get_run(run_id)
+            assert "to-remove" not in result.tags
+            assert "keep" in result.tags
+        finally:
+            # Cleanup
+            import shutil
+            run_path = storage.get_run_path(run_id)
+            if run_path.exists():
+                shutil.rmtree(run_path)
+            RunService.reset()
+
+    def test_remove_tag_noop_if_not_present(self, tmp_path, monkeypatch):
+        """remove_tag should not invalidate cache if tag wasn't present."""
+        monkeypatch.setattr(storage, "RUNS_DIR", tmp_path)
+
+        RunService.reset()
+        service = RunService.get_instance(tmp_path)
+
+        run_id = "cache-remove-noop-test"
+        now = datetime.now(timezone.utc)
+        summary = RunSummary(
+            id=run_id,
+            spec=RunSpec(flow_keys=["signal"], backend="claude-harness", initiator="test"),
+            status=RunStatus.FAILED,
+            sdlc_status=SDLCStatus.ERROR,
+            created_at=now,
+            updated_at=now,
+            tags=["existing"],
+        )
+        storage.write_summary(run_id, summary)
+
+        try:
+            # Populate cache
+            cached = service.get_run(run_id)
+            assert run_id in service._summary_cache
+
+            # Try to remove non-existent tag (should NOT invalidate cache)
+            service.remove_tag(run_id, "non-existent")
+            assert run_id in service._summary_cache
+
+            # Should still be the same cached object
+            assert service.get_run(run_id) is cached
         finally:
             # Cleanup
             import shutil


### PR DESCRIPTION
## Summary

- Cache terminal run summaries (SUCCEEDED/FAILED/CANCELED) in RunService to avoid repeated disk reads during `list_runs()`
- Add thread-safe locking for Flask multi-threaded compatibility
- Add proper cache invalidation on mutations (mark_exemplar, add_tag, remove_tag)
- Clear cache on `RunService.reset()` for test isolation

**Replaces PR #93** (Jules: Cache terminal run summaries in RunService) with maintainer improvements.

## Modern Dev Metrics

### Change Shape
| Metric | Value |
|--------|-------|
| Base | `main` @ `8a46f88` |
| Head | `maint/pr-93-run-service-caching-20260120` |
| Files changed | 2 |
| Insertions | +294 |
| Deletions | -4 |
| Commits | 2 (1 cherry-picked from Jules, 1 maintainer improvements) |

### Start Review Here
1. `swarm/runtime/service.py` - Core caching logic and thread-safety

### Blast Radius
- **Public API**: No changes to public interface
- **Protocol/IO boundary**: No
- **Config/flags**: No
- **Persistence/schema**: No (in-memory cache only)
- **Concurrency**: Yes - adds thread-safe locking to RunService

### Hotspot Context
- `swarm/runtime/service.py` is load-bearing (used by Flow Studio, CLI, API)
- Change is additive (caching layer) with thread-safe guards

### Verification Receipts

```
$ uv run pytest tests/test_run_service.py -v
22 passed in 2.70s

$ uv run ruff check swarm/runtime/service.py tests/test_run_service.py
All checks passed!
```

**What wasn't run:**
- Full test suite (focused on changed module)
- mypy (not configured for this repo)

### Risk + Rollback
- **Risk class**: LOW - additive caching with thread-safe guards
- **Rollback plan**: Revert commit or remove cache dict and lock

### Decision Log

**Choices made:**
1. **Thread-safety via Lock** vs atomics/concurrent dict: Lock is simpler and sufficient for RunService singleton pattern
2. **Cache terminal states only**: Non-terminal runs may change status, so caching them would serve stale data
3. **Invalidate on mutation** vs update-in-place: Invalidation is safer; next read will get fresh data
4. **Clear cache on reset()**: Essential for test isolation; prevents test pollution across runs

**What was NOT done:**
- LRU eviction (cache grows unbounded, but terminal runs are finite)
- Cache warming (lazy population on-demand is sufficient)
- Persisted cache (in-memory only; restarts start fresh)

## Test Plan

- [x] Cache hit for terminal runs (SUCCEEDED, FAILED, CANCELED)
- [x] No cache for non-terminal runs (PENDING, RUNNING)
- [x] Cache invalidation on mark_exemplar()
- [x] Cache invalidation on add_tag()
- [x] clear_cache() empties entire cache
- [x] RunService.reset() clears cache for test isolation