### PR TITLE
a11y: add close button to keyboard shortcuts modal

### DIFF
--- a/swarm/tools/flow_studio_ui/fragments/60-modals.html
+++ b/swarm/tools/flow_studio_ui/fragments/60-modals.html
@@ -10,6 +10,7 @@
 <!-- Keyboard shortcuts modal -->
 <div id="shortcuts-modal" class="shortcuts-modal" role="dialog" aria-modal="true" aria-labelledby="shortcuts-modal-title" data-uiid="flow_studio.modal.shortcuts">
   <div class="shortcuts-content">
+    <button id="shortcuts-modal-close" class="selftest-modal-close" aria-label="Close shortcuts modal" data-uiid="flow_studio.modal.shortcuts.close">×</button>
     <h3 id="shortcuts-modal-title">Keyboard Shortcuts</h3>
     <div class="shortcut-row">
       <span class="shortcut-desc">Focus search</span>

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -242,6 +242,7 @@ make validate-swarm</pre>
 <!-- Keyboard shortcuts modal -->
 <div id="shortcuts-modal" class="shortcuts-modal" role="dialog" aria-modal="true" aria-labelledby="shortcuts-modal-title" data-uiid="flow_studio.modal.shortcuts">
   <div class="shortcuts-content">
+    <button id="shortcuts-modal-close" class="selftest-modal-close" aria-label="Close shortcuts modal" data-uiid="flow_studio.modal.shortcuts.close">×</button>
     <h3 id="shortcuts-modal-title">Keyboard Shortcuts</h3>
     <div class="shortcut-row">
       <span class="shortcut-desc">Focus search</span>
@@ -9456,6 +9457,13 @@ export function initShortcutsModal() {
             toggleShortcutsModal(false);
         }
     });
+    // Close button click handler
+    const closeBtn = document.getElementById("shortcuts-modal-close");
+    if (closeBtn) {
+        closeBtn.addEventListener("click", () => {
+            toggleShortcutsModal(false);
+        });
+    }
     // Close on ESC key within the modal
     modal.addEventListener("keydown", (e) => {
         if (e.key === "Escape") {

--- a/swarm/tools/flow_studio_ui/js/shortcuts.js
+++ b/swarm/tools/flow_studio_ui/js/shortcuts.js
@@ -63,6 +63,13 @@ export function initShortcutsModal() {
             toggleShortcutsModal(false);
         }
     });
+    // Close button click handler
+    const closeBtn = document.getElementById("shortcuts-modal-close");
+    if (closeBtn) {
+        closeBtn.addEventListener("click", () => {
+            toggleShortcutsModal(false);
+        });
+    }
     // Close on ESC key within the modal
     modal.addEventListener("keydown", (e) => {
         if (e.key === "Escape") {

--- a/swarm/tools/flow_studio_ui/src/shortcuts.ts
+++ b/swarm/tools/flow_studio_ui/src/shortcuts.ts
@@ -70,6 +70,14 @@ export function initShortcutsModal(): void {
     }
   });
 
+  // Close button click handler
+  const closeBtn = document.getElementById("shortcuts-modal-close");
+  if (closeBtn) {
+    closeBtn.addEventListener("click", () => {
+      toggleShortcutsModal(false);
+    });
+  }
+
   // Close on ESC key within the modal
   modal.addEventListener("keydown", (e: KeyboardEvent) => {
     if (e.key === "Escape") {


### PR DESCRIPTION
## Summary

Add a visible close button (×) to the keyboard shortcuts modal for improved accessibility and discoverability. Previously users could only close the modal via Escape key or backdrop click.

**What changed:**
- Add `<button>` element with `aria-label="Close shortcuts modal"` to the shortcuts modal
- Add click handler in `shortcuts.ts` that calls `toggleShortcutsModal(false)`
- Uses existing `selftest-modal-close` styling for visual consistency

**Why:**
- WCAG recommends visible dismissal affordances for modal dialogs
- Improves discoverability for users who don't know keyboard shortcuts
- Consistent with other modals in Flow Studio (selftest, run detail)

---

## Glass Cockpit Telemetry

### Change Shape
| Metric | Value |
|--------|-------|
| Base | `main` @ `8a46f88` |
| Head | `maint/pr-90-shortcuts-close-btn-20260120` @ `89f44dc` |
| Commits | 1 |
| Files | 4 |
| Insertions | +369 |
| Deletions | -18 |

**Start review here:** `swarm/tools/flow_studio_ui/fragments/60-modals.html` (1-line HTML change)

### Blast Radius
| Surface | Affected? |
|---------|-----------|
| Public API | No |
| Protocol/IO boundary | No |
| Config/flags | No |
| Persistence/schema | No |
| Concurrency | No |
| UI (Flow Studio) | Yes - shortcuts modal only |

### Hotspot/Churn Context
- `60-modals.html` - low churn, contains modal markup
- `shortcuts.ts` - moderate churn, recently added focus management
- `index.html` - generated file, reflects source drift correction

### Verification Receipts

| Check | Command | Result |
|-------|---------|--------|
| TypeScript | `npm run ts-check` | ✅ Pass |
| Swarm validation | `uv run swarm/tools/validate_swarm.py` | ✅ Pass |

**Not run:**
- Python tests (no Python changes)
- E2E tests (no test infrastructure for UI modals)

### Risk + Rollback
- **Risk class:** Low (UI-only, single modal, no state changes)
- **Rollback:** `git revert <commit>` or remove button from fragment

### Decision Log

1. **Why extracted from #90:** Original PR bundled ~500 lines of unrelated features (toast notifications, routing tabs, autopilot support, SSE race condition fixes) with a 15-line accessibility fix. Extracted just the a11y work for clean review.

2. **Why button vs other affordance:** Consistent with existing selftest and run-detail modals. `<button>` provides keyboard accessibility out of the box.

3. **Why index.html shows large diff:** Generated `index.html` was out of sync with TypeScript source on `main`. Regenerating it pulled in already-merged source changes. This sync is incidental but beneficial.

---

Supersedes: #90