### PR TITLE
a11y: add ARIA labels to NodeInspector icon buttons

### DIFF
--- a/swarm/tools/flow_studio_ui/js/components/NodeInspector.js
+++ b/swarm/tools/flow_studio_ui/js/components/NodeInspector.js
@@ -315,7 +315,7 @@ export class NodeInspector {
             tagsContainer.innerHTML = values.map(v => `
         <span class="node-inspector__tag">
           ${escapeHtml(v)}
-          <button type="button" class="node-inspector__tag-remove" data-value="${escapeHtml(v)}">\u00D7</button>
+          <button type="button" class="node-inspector__tag-remove" data-value="${escapeHtml(v)}" aria-label="Remove agent" title="Remove agent">\u00D7</button>
         </span>
       `).join("");
             // Add remove handlers
@@ -366,7 +366,7 @@ export class NodeInspector {
         <div class="node-inspector__list-items"></div>
         <div class="node-inspector__list-add">
           <input type="text" class="node-inspector__list-add-input" placeholder="${escapeHtml(placeholder)}" />
-          <button type="button" class="node-inspector__list-add-btn">+</button>
+          <button type="button" class="node-inspector__list-add-btn" aria-label="Add item" title="Add item">+</button>
         </div>
       </div>
     `;
@@ -378,7 +378,7 @@ export class NodeInspector {
             itemsContainer.innerHTML = values.map((v, i) => `
         <div class="node-inspector__list-item">
           <span class="node-inspector__list-item-text mono">${escapeHtml(v)}</span>
-          <button type="button" class="node-inspector__list-item-remove" data-index="${i}">\u00D7</button>
+          <button type="button" class="node-inspector__list-item-remove" data-index="${i}" aria-label="Remove item" title="Remove item">\u00D7</button>
         </div>
       `).join("");
             // Add remove handlers

--- a/swarm/tools/flow_studio_ui/src/components/NodeInspector.ts
+++ b/swarm/tools/flow_studio_ui/src/components/NodeInspector.ts
@@ -481,7 +481,7 @@ export class NodeInspector {
       tagsContainer.innerHTML = values.map(v => `
         <span class="node-inspector__tag">
           ${escapeHtml(v)}
-          <button type="button" class="node-inspector__tag-remove" data-value="${escapeHtml(v)}">\u00D7</button>
+          <button type="button" class="node-inspector__tag-remove" data-value="${escapeHtml(v)}" aria-label="Remove agent" title="Remove agent">\u00D7</button>
         </span>
       `).join("");
 
@@ -543,7 +543,7 @@ export class NodeInspector {
         <div class="node-inspector__list-items"></div>
         <div class="node-inspector__list-add">
           <input type="text" class="node-inspector__list-add-input" placeholder="${escapeHtml(placeholder)}" />
-          <button type="button" class="node-inspector__list-add-btn">+</button>
+          <button type="button" class="node-inspector__list-add-btn" aria-label="Add item" title="Add item">+</button>
         </div>
       </div>
     `;
@@ -557,7 +557,7 @@ export class NodeInspector {
       itemsContainer.innerHTML = values.map((v, i) => `
         <div class="node-inspector__list-item">
           <span class="node-inspector__list-item-text mono">${escapeHtml(v)}</span>
-          <button type="button" class="node-inspector__list-item-remove" data-index="${i}">\u00D7</button>
+          <button type="button" class="node-inspector__list-item-remove" data-index="${i}" aria-label="Remove item" title="Remove item">\u00D7</button>
         </div>
       `).join("");
 


### PR DESCRIPTION
## Summary

- Add `aria-label` and `title` attributes to icon-only buttons in NodeInspector component
- Tag removal buttons now announce "Remove agent"
- List item removal buttons now announce "Remove item"
- List item add buttons now announce "Add item"

Supersedes #95 (cherry-picked onto latest main with maintainer improvements).

---

## Modern Dev Metrics

### Change Shape
| Metric | Value |
|--------|-------|
| Base ref | `main` @ `8a46f88` |
| Head ref | `maint/pr-95-nodeinspector-a11y-20260120` @ `3241a7a` |
| Commits | 1 |
| Files changed | 2 |
| Diffstat |  2 files changed, 6 insertions(+), 6 deletions(-) |

**Start review here:** `NodeInspector.ts` (source), then `NodeInspector.js` (compiled)

### Blast Radius
| Surface | Affected? |
|---------|-----------|
| Public API | No |
| Protocol/IO boundary | No |
| Config/flags | No |
| Persistence/schema | No |
| Concurrency | No |
| **UI/Accessibility** | Yes (ARIA labels added to buttons) |

### Hotspot / Churn Context
- `NodeInspector.ts`: Component for inspecting node details, moderate churn
- `NodeInspector.js`: Compiled artifact, regenerated from TS source

### Verification Receipts
| Check | Command | Result |
|-------|---------|--------|
| TypeScript build | `npm run ts-build` | ✅ PASSED |
| TypeScript check | `npm run ts-check` | ✅ PASSED |
| Swarm validation | `uv run swarm/tools/validate_swarm.py` | ✅ PASSED |

**Not run:** Python tests (no Python changes), E2E tests (a11y change only)

### Risk + Rollback
- **Risk class:** Low (additive ARIA attributes, no behavior change)
- **Rollback plan:** `git revert <sha>` - change is self-contained

---

## Decision Log

1. **Applied** Jules PR #95 changes directly to TypeScript source (not compiled JS)
2. **Regenerated** `NodeInspector.js` via `npm run ts-build` instead of manual edits
3. **Removed** `.Jules/palette.md` journal file (not appropriate for codebase)
4. **Added** ARIA label to Add button (+) which Jules missed - completing the a11y coverage
5. **Kept** original labels ("Remove agent", "Remove item", "Add item") - they match context