### PR TITLE
a11y: convert profile badge to semantic button with correct ARIA placement

### DIFF
--- a/swarm/tools/flow_studio_ui/fragments/10-header.html
+++ b/swarm/tools/flow_studio_ui/fragments/10-header.html
@@ -20,10 +20,10 @@
         <button id="mode-author" class="active" title="Show all paths, CLI commands, and technical details" aria-pressed="true" data-uiid="flow_studio.header.mode.author">Author</button>
         <button id="mode-operator" title="Simplified view focused on run status and decisions" aria-pressed="false" data-uiid="flow_studio.header.mode.operator">Operator</button>
       </div>
-      <div id="profile-badge" class="muted fs-profile-badge" style="display: flex; align-items: center; gap: 6px; cursor: pointer;" title="Current swarm profile" role="status" aria-live="polite" data-uiid="flow_studio.header.profile">
+      <button id="profile-badge" class="muted fs-status-button fs-profile-badge" title="Current swarm profile" data-uiid="flow_studio.header.profile">
         <span id="profile-icon" aria-hidden="true">&#128230;</span>
-        <span id="profile-text">Profile: Loading...</span>
-      </div>
+        <span id="profile-text" aria-live="polite">Profile: Loading...</span>
+      </button>
       <button id="governance-badge" class="muted fs-status-button" title="Click to view governance status" data-uiid="flow_studio.header.governance">
         <span id="governance-icon" aria-hidden="true">⏳</span>
         <span id="governance-text" aria-live="polite">Checking...</span>

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -37,10 +37,10 @@
         <button id="mode-author" class="active" title="Show all paths, CLI commands, and technical details" aria-pressed="true" data-uiid="flow_studio.header.mode.author">Author</button>
         <button id="mode-operator" title="Simplified view focused on run status and decisions" aria-pressed="false" data-uiid="flow_studio.header.mode.operator">Operator</button>
       </div>
-      <div id="profile-badge" class="muted fs-profile-badge" style="display: flex; align-items: center; gap: 6px; cursor: pointer;" title="Current swarm profile" role="status" aria-live="polite" data-uiid="flow_studio.header.profile">
+      <button id="profile-badge" class="muted fs-status-button fs-profile-badge" title="Current swarm profile" data-uiid="flow_studio.header.profile">
         <span id="profile-icon" aria-hidden="true">&#128230;</span>
-        <span id="profile-text">Profile: Loading...</span>
-      </div>
+        <span id="profile-text" aria-live="polite">Profile: Loading...</span>
+      </button>
       <button id="governance-badge" class="muted fs-status-button" title="Click to view governance status" data-uiid="flow_studio.header.governance">
         <span id="governance-icon" aria-hidden="true">⏳</span>
         <span id="governance-text" aria-live="polite">Checking...</span>


### PR DESCRIPTION
## Summary

Convert the profile badge from a `<div>` to a `<button>` for proper keyboard accessibility, with correct ARIA live region placement.

**Changes:**
- Convert `<div id="profile-badge">` to `<button>` for native keyboard/focus support
- Add `fs-status-button` class (matches existing `governance-badge` pattern)
- Move `aria-live="polite"` from button to inner `#profile-text` span (live regions should wrap dynamic text, not interactive elements)
- Remove inline styles (handled by utility class)
- Remove `role="status"` (inappropriate for interactive button)

Supersedes #169 with maintainer improvements.

---

## Modern Dev Metrics

### Change Shape
| Metric | Value |
|--------|-------|
| Base | `main` @ `6c6c1ee` |
| Head | `maint/pr-169-profile-badge-a11y-20260121` @ `24371ce` |
| Diffstat | 2 files changed, 6 insertions(+), 6 deletions(-) |
| Commits | 1 |

### Files Changed (start review here)
1. `swarm/tools/flow_studio_ui/fragments/10-header.html` — source fragment
2. `swarm/tools/flow_studio_ui/index.html` — generated output

### Blast Radius
| Surface | Impact |
|---------|--------|
| Public API | None |
| Protocol/IO | None |
| Config/Flags | None |
| Persistence | None |
| Concurrency | None |
| UI/DOM | **Yes** — button element replaces div, ARIA attributes repositioned |

### Hotspot / Churn Context
- `10-header.html` — Moderate churn (recent a11y standardization work)
- Change follows established pattern (`governance-badge` uses identical structure)

### Verification Receipts
| Check | Command | Result |
|-------|---------|--------|
| TypeScript | `npx tsc --noEmit` | ✅ Pass (no output) |
| Swarm validation | `uv run swarm/tools/validate_swarm.py` | ✅ Pass |
| Index regen | `uv run swarm/tools/gen_index_html.py` | ✅ Generated |

**Not run:** Python tests (no Python changes), E2E browser tests (no automation in CI)

### Risk + Rollback
- **Risk class:** Low — cosmetic/a11y change, no logic changes
- **Rollback:** `git revert <commit-sha>` + regenerate index.html

---

## Decision Log

### Why this approach?
1. **Button vs div:** Native buttons provide keyboard focus, Enter/Space activation, and proper ARIA role without extra work. The div required `role="status"` and `cursor: pointer` inline.

2. **aria-live placement:** Jules PR placed `aria-live="polite"` on the button element. This is semantically incorrect—live regions announce *content changes*, and should wrap the text that updates (`#profile-text`), not the interactive container. The `governance-badge` in this codebase already uses the correct pattern.

3. **Removed `.Jules/palette.md`:** Bot journal file should not be committed to repo.

4. **fs-status-button class:** Reuses existing utility class that already handles flex layout, gap, cursor, and focus-visible states—eliminating inline styles.

### What I explicitly did NOT do
- No JavaScript changes (element ID unchanged, existing handlers work)
- No CSS changes (existing classes handle styling)
- No scope expansion beyond the profile badge