### PR TITLE
perf: optimize run discovery with os.scandir in individual functions

### DIFF
--- a/swarm/runtime/storage.py
+++ b/swarm/runtime/storage.py
@@ -74,6 +74,10 @@ EVENTS_FILE = "events.jsonl"
 RUN_STATE_FILE = "run_state.json"
 LEGACY_META_FILE = "run.json"  # Old-style optional metadata
 
+# Flow keys used for detecting legacy runs (runs without meta.json)
+# These are the core flows that produce artifact directories
+LEGACY_FLOW_KEYS = frozenset({"signal", "plan", "build", "gate", "deploy", "wisdom"})
+
 # -----------------------------------------------------------------------------
 # Per-run locking for thread safety
 # -----------------------------------------------------------------------------
@@ -832,9 +836,17 @@ def list_runs(runs_dir: Path = RUNS_DIR) -> List[RunId]:
         return []
 
     run_ids: List[RunId] = []
-    for entry in runs_dir.iterdir():
-        if entry.is_dir() and (entry / META_FILE).exists():
-            run_ids.append(entry.name)
+    # Use os.scandir for faster directory iteration - avoids Path object overhead
+    # and leverages cached stat info from DirEntry objects
+    try:
+        with os.scandir(runs_dir) as it:
+            for entry in it:
+                if entry.is_dir():
+                    # Use os.path for faster file existence check
+                    if os.path.exists(os.path.join(entry.path, META_FILE)):
+                        run_ids.append(entry.name)
+    except OSError:
+        pass
 
     return sorted(run_ids)
 
@@ -855,23 +867,26 @@ def discover_legacy_runs(runs_dir: Path = RUNS_DIR) -> List[RunId]:
     if not runs_dir.exists():
         return []
 
-    # Known flow keys that indicate a valid run directory
-    flow_keys = {"signal", "plan", "build", "gate", "deploy", "wisdom"}
-
     legacy_runs: List[RunId] = []
-    for entry in runs_dir.iterdir():
-        if not entry.is_dir():
-            continue
+    # Use os.scandir for faster directory iteration
+    try:
+        with os.scandir(runs_dir) as it:
+            for entry in it:
+                if not entry.is_dir():
+                    continue
 
-        # Skip if already has meta.json (not legacy)
-        if (entry / META_FILE).exists():
-            continue
+                # Skip if already has meta.json (not legacy)
+                if os.path.exists(os.path.join(entry.path, META_FILE)):
+                    continue
 
-        # Check if any flow subdirectory exists
-        has_flow_artifacts = any((entry / flow_key).is_dir() for flow_key in flow_keys)
-
-        if has_flow_artifacts:
-            legacy_runs.append(entry.name)
+                # Check if any flow subdirectory exists
+                # Use os.path.isdir with early exit for efficiency
+                for flow_key in LEGACY_FLOW_KEYS:
+                    if os.path.isdir(os.path.join(entry.path, flow_key)):
+                        legacy_runs.append(entry.name)
+                        break
+    except OSError:
+        pass
 
     return sorted(legacy_runs)
 
@@ -888,19 +903,22 @@ def discover_example_runs() -> List[RunId]:
     if not EXAMPLES_DIR.exists():
         return []
 
-    # Known flow keys that indicate a valid run directory
-    flow_keys = {"signal", "plan", "build", "gate", "deploy", "wisdom"}
-
     example_runs: List[RunId] = []
-    for entry in EXAMPLES_DIR.iterdir():
-        if not entry.is_dir() or entry.name.startswith("."):
-            continue
+    # Use os.scandir for faster directory iteration
+    try:
+        with os.scandir(EXAMPLES_DIR) as it:
+            for entry in it:
+                if not entry.is_dir() or entry.name.startswith("."):
+                    continue
 
-        # Check if any flow subdirectory exists
-        has_flow_artifacts = any((entry / flow_key).is_dir() for flow_key in flow_keys)
-
-        if has_flow_artifacts:
-            example_runs.append(entry.name)
+                # Check if any flow subdirectory exists
+                # Use os.path.isdir with early exit for efficiency
+                for flow_key in LEGACY_FLOW_KEYS:
+                    if os.path.isdir(os.path.join(entry.path, flow_key)):
+                        example_runs.append(entry.name)
+                        break
+    except OSError:
+        pass
 
     return sorted(example_runs)
 


### PR DESCRIPTION
## Summary

Optimizes the individual run discovery functions (`list_runs()`, `discover_legacy_runs()`, `discover_example_runs()`) by replacing `pathlib.iterdir()` with `os.scandir()` for faster directory traversal.

**Key changes:**
- Add `LEGACY_FLOW_KEYS` constant for DRY flow key references (removes duplication)
- Use `os.scandir()` context manager for efficient directory iteration
- Use `os.path.join`/`exists`/`isdir` instead of Path object creation overhead
- Add early-exit loop for flow key detection in legacy/example scanning

---

## Glass Cockpit Telemetry

### Change Shape
| Metric | Value |
|--------|-------|
| Base ref | `main` @ `6c6c1ee` |
| Head ref | `maint/pr-165-scandir-individual-20260121` @ `a6a722d` |
| Files changed | 1 |
| Insertions | +46 |
| Deletions | -28 |
| Commits | 1 |

**Start review here:** `swarm/runtime/storage.py:77-89` (constant + updated functions)

### Blast Radius / Surface Area
| Category | Impact |
|----------|--------|
| Public API | ⚪ None - function signatures unchanged |
| Protocol/IO boundary | ⚪ None |
| Config/flags | ⚪ None |
| Persistence/schema | ⚪ None |
| Concurrency | ⚪ None - scandir context manager handles cleanup |

### Hotspot / Churn Context
- `swarm/runtime/storage.py` has had 4 commits since Dec 2025 (moderate activity)
- This file is load-bearing for run discovery across the codebase
- Changes are isolated to the run listing functions section (lines 818-923)

### Verification Receipts
```bash
# Run service tests (all 27 passed)
uv run pytest tests/test_run_service.py -v
# Result: 27 passed in 4.05s

# Run inspector tests (all 44 passed)  
uv run pytest tests/test_run_inspector.py -v
# Result: 44 passed in 0.26s

# Storage-related tests (all 22 passed)
uv run pytest tests/ -k "storage or list_run or discover" -v
# Result: 22 passed in 10.37s

# Syntax validation
python -m py_compile swarm/runtime/storage.py
# Result: OK
```

**Not run:** Type checking (mypy not configured in repo), performance benchmarks (no harness available)

### Risk + Rollback
| Risk | Level | Mitigation |
|------|-------|------------|
| Behavioral change | 🟢 Low | Function signatures and return types unchanged |
| Error handling | 🟢 Low | Matches existing `OSError` handling pattern in codebase |
| Performance regression | 🟢 Low | `os.scandir` is strictly faster than `pathlib.iterdir` |

**Rollback plan:** Revert commit `a6a722d`

### Decision Log

1. **Chose to refactor instead of adding `scan_runs()` consolidation**: The individual functions (`list_runs()`, `discover_legacy_runs()`, `discover_example_runs()`) are called independently by various callers. Consolidating them would break the API. Optimizing each independently maintains backward compatibility.

2. **Added `LEGACY_FLOW_KEYS` constant**: The flow keys set was duplicated in two functions. Extracting to a module-level `frozenset` provides DRY and immutability.

3. **Removed Jules's `.jules/bolt.md` file**: Jules's PR added a learnings file that doesn't belong in this repo's structure.

4. **Kept silent `except OSError: pass`**: This matches the pattern used elsewhere in the storage module (e.g., if directory doesn't exist mid-scan). The early `runs_dir.exists()` check handles the common case.

---

Supersedes #165