### PR TITLE
perf: use JSON serialization for faster dict copying

### DIFF
--- a/swarm/api/services/spec_manager.py
+++ b/swarm/api/services/spec_manager.py
@@ -207,9 +207,8 @@ class SpecManager:
             raise ValueError(f"ETag mismatch: expected {expected_etag}, got {current_etag}")
 
         # Apply JSON Patch operations
-        import copy
-
-        updated_data = copy.deepcopy(flow_data)
+        # Optimization: json.loads(json.dumps(x)) is ~2x faster than copy.deepcopy(x) for large dicts
+        updated_data = json.loads(json.dumps(flow_data))
 
         for op in patch_operations:
             operation = op.get("op")

--- a/swarm/spec/compiler_legacy.py
+++ b/swarm/spec/compiler_legacy.py
@@ -1483,10 +1483,9 @@ def expand_flow_graph(
         >>> print(expanded["nodes"][0]["station_id"])
         'requirements-author'
     """
-    import copy
-
     # Deep copy to avoid mutating input
-    result = copy.deepcopy(flow_data)
+    # Optimization: json.loads(json.dumps(x)) is ~2x faster than copy.deepcopy(x) for large dicts
+    result = json.loads(json.dumps(flow_data))
 
     expanded_nodes = []
     for node in result.get("nodes", []):


### PR DESCRIPTION
## Summary

Replaces `copy.deepcopy()` with `json.loads(json.dumps())` for deep copying flow graph dictionaries in hot paths.

**Supersedes:** #159

## Change Shape

| Metric | Value |
|--------|-------|
| Base ref | `main` @ `6c6c1ee` |
| Head ref | `maint/pr-159-json-deepcopy-20260121` |
| Files changed | 2 |
| Lines | +4 / -6 |
| Commits | 1 |

**Files to review:**
1. `swarm/api/services/spec_manager.py` - `update_flow()` method
2. `swarm/spec/compiler_legacy.py` - `expand_flow_graph()` function

## Blast Radius / Surface Area

| Surface | Impact |
|---------|--------|
| Public API | No - internal implementation detail |
| Protocol/IO boundary | No |
| Config/flags | No |
| Persistence/schema | No |
| Concurrency | No |

**Blast radius: LOW** - Pure performance optimization of internal copy operations.

## Why This Works

The `json.loads(json.dumps(x))` pattern is safe here because:
1. Flow data comes from YAML config files containing only JSON-compatible types (dicts, lists, strings, numbers, booleans, nulls)
2. Both files already import `json` at module level
3. No custom objects, datetimes, bytes, or non-string dict keys in flow data

## Hotspot / Churn Context

- `spec_manager.py` - moderate churn (API services layer)
- `compiler_legacy.py` - low churn (stable legacy code)

Neither file is in the high-churn hotspot list.

## Verification Receipts

**Benchmark (flow-like data, 1000 iterations):**
```
copy.deepcopy: 0.0473s
json.loads/dumps: 0.0200s
Speedup: 2.36x
```

**Tests run:**
```bash
uv run python -m pytest tests/test_spec_*.py -v --tb=short
# Result: 249 passed, 1 skipped

uv run python swarm/tools/validate_swarm.py --strict
# Result: PASSED

uv run python -m pytest tests/test_flow_studio_fastapi_smoke.py -v --tb=short
# Result: 11 passed, 3 skipped
```

**Module smoke test:**
```
SpecManager.get_flow: OK - signal has 6 steps
expand_flow_graph: OK
JSON copy equivalence: OK (deepcopy == json copy)
```

**What wasn't run:**
- Full test suite (not necessary for this isolated change)
- Performance benchmarks on production data (microbenchmark sufficient)

## Risk + Rollback

**Risk class: LOW**
- Change is isolated to two copy operations
- Flow data is guaranteed JSON-serializable
- No behavioral change, only performance

**Rollback plan:**
- Revert commit (changes are self-contained)
- No data migration required

## Decision Log

1. **Considered:** Keep `copy.deepcopy` for safety → Rejected: benchmarks confirm 2.36x overhead with no benefit for JSON-compatible data
2. **Considered:** Add explicit type assertions → Rejected: over-engineering; flow data schema is stable and JSON-derived
3. **Chosen:** Direct replacement with descriptive comment explaining the optimization

The original Jules PR was well-conceived. This replacement adds verification receipts and rebases onto latest main.