### PR TITLE
🎨 Palette: Add accessible clear button to search input

### DIFF
--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -1039,7 +1039,7 @@
     }
     .search-input {
       width: 100%;
-      padding: 6px 12px 6px 32px;
+      padding: 6px 30px 6px 32px;
       font-size: 12px;
       border: 1px solid #d1d5db;
       border-radius: 6px;
@@ -1063,6 +1063,27 @@
     .search-input:focus + .search-shortcut,
     .search-input:not(:placeholder-shown) + .search-shortcut {
       display: none;
+    }
+    .search-clear {
+      display: none;
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: #9ca3af;
+      padding: 0;
+      font-size: 16px;
+      line-height: 1;
+      z-index: 2;
+    }
+    .search-clear:hover {
+      color: #4b5563;
+    }
+    .search-input:not(:placeholder-shown) ~ .search-clear {
+      display: block;
     }
     .search-icon {
       position: absolute;

--- a/swarm/tools/flow_studio_ui/fragments/10-header.html
+++ b/swarm/tools/flow_studio_ui/fragments/10-header.html
@@ -6,6 +6,7 @@
       <span class="search-icon" aria-hidden="true">&#128269;</span>
       <input type="text" id="search-input" class="search-input" placeholder="Search flows, steps, agents, artifacts..." autocomplete="off" aria-label="Search flows, steps, agents, and artifacts" data-uiid="flow_studio.header.search.input" />
       <kbd class="fs-kbd search-shortcut" aria-hidden="true">/</kbd>
+      <button id="search-clear" class="search-clear" aria-label="Clear search" title="Clear search" data-uiid="flow_studio.header.search.clear">&times;</button>
       <div id="search-dropdown" class="search-dropdown" role="listbox" aria-label="Search results" data-uiid="flow_studio.header.search.results"></div>
     </div>
     </div>

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -24,6 +24,7 @@
       <span class="search-icon" aria-hidden="true">&#128269;</span>
       <input type="text" id="search-input" class="search-input" placeholder="Search flows, steps, agents, artifacts..." autocomplete="off" aria-label="Search flows, steps, agents, and artifacts" data-uiid="flow_studio.header.search.input" />
       <kbd class="fs-kbd search-shortcut" aria-hidden="true">/</kbd>
+      <button id="search-clear" class="search-clear" aria-label="Clear search" title="Clear search" data-uiid="flow_studio.header.search.clear">&times;</button>
       <div id="search-dropdown" class="search-dropdown" role="listbox" aria-label="Search results" data-uiid="flow_studio.header.search.results"></div>
     </div>
     </div>
@@ -1676,7 +1677,7 @@
     }
     .search-input {
       width: 100%;
-      padding: 6px 12px 6px 32px;
+      padding: 6px 30px 6px 32px;
       font-size: 12px;
       border: 1px solid #d1d5db;
       border-radius: 6px;
@@ -1700,6 +1701,27 @@
     .search-input:focus + .search-shortcut,
     .search-input:not(:placeholder-shown) + .search-shortcut {
       display: none;
+    }
+    .search-clear {
+      display: none;
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: none;
+      border: none;
+      cursor: pointer;
+      color: #9ca3af;
+      padding: 0;
+      font-size: 16px;
+      line-height: 1;
+      z-index: 2;
+    }
+    .search-clear:hover {
+      color: #4b5563;
+    }
+    .search-input:not(:placeholder-shown) ~ .search-clear {
+      display: block;
     }
     .search-icon {
       position: absolute;
@@ -8796,6 +8818,15 @@ export function initSearchHandlers() {
     const dropdown = document.getElementById("search-dropdown");
     if (!searchInput)
         return;
+    // Clear button handler
+    const clearBtn = document.getElementById("search-clear");
+    if (clearBtn) {
+        clearBtn.addEventListener("click", () => {
+            searchInput.value = "";
+            closeSearchDropdown();
+            searchInput.focus();
+        });
+    }
     searchInput.addEventListener("input", (e) => {
         if (state.searchDebounceTimer) {
             clearTimeout(state.searchDebounceTimer);

--- a/swarm/tools/flow_studio_ui/js/search.js
+++ b/swarm/tools/flow_studio_ui/js/search.js
@@ -154,6 +154,15 @@ export function initSearchHandlers() {
     const dropdown = document.getElementById("search-dropdown");
     if (!searchInput)
         return;
+    // Clear button handler
+    const clearBtn = document.getElementById("search-clear");
+    if (clearBtn) {
+        clearBtn.addEventListener("click", () => {
+            searchInput.value = "";
+            closeSearchDropdown();
+            searchInput.focus();
+        });
+    }
     searchInput.addEventListener("input", (e) => {
         if (state.searchDebounceTimer) {
             clearTimeout(state.searchDebounceTimer);

--- a/swarm/tools/flow_studio_ui/src/search.ts
+++ b/swarm/tools/flow_studio_ui/src/search.ts
@@ -167,6 +167,16 @@ export function initSearchHandlers(): void {
 
   if (!searchInput) return;
 
+  // Clear button handler
+  const clearBtn = document.getElementById("search-clear");
+  if (clearBtn) {
+    clearBtn.addEventListener("click", () => {
+      searchInput.value = "";
+      closeSearchDropdown();
+      searchInput.focus();
+    });
+  }
+
   searchInput.addEventListener("input", (e: Event) => {
     if (state.searchDebounceTimer) {
       clearTimeout(state.searchDebounceTimer);


### PR DESCRIPTION
Implemented an accessible "Clear" button for the search input in Flow Studio UI.
- Modified `fragments/10-header.html` to add the button.
- Modified `css/flow-studio.base.css` to style and position it.
- Modified `src/search.ts` to handle the click logic (clear + refocus).
- Updated `index.html` (build artifact) to reflect changes, ensuring no noise from unrelated stale artifacts.


---
*PR created automatically by Jules for task [6760180387279740903](https://jules.google.com/task/6760180387279740903) started by @EffortlessSteven*