### PR TITLE
⚡ Bolt: Optimize run listing with cache lookup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+
+## 2026-01-23 - Cache Lookup in Run Listing
+**Learning:** Even with deferred file existence checks, `RunStateManager.list_runs` was still reading and parsing `run_state.json` from disk for every candidate run, causing a bottleneck when listing many runs.
+**Action:** Implemented a cache lookup in `list_runs` to use the in-memory `_cache` if available, reducing `Path.read_text` calls to zero for cached runs.

--- a/swarm/api/services/run_state.py
+++ b/swarm/api/services/run_state.py
@@ -174,12 +174,24 @@ class RunStateManager:
             if len(runs) >= limit:
                 break
 
-            state_path = run_dir / "run_state.json"
-            if not state_path.exists():
-                continue
+            run_id = run_dir.name
+            state = None
 
-            try:
-                state = json.loads(state_path.read_text(encoding="utf-8"))
+            # Check cache first
+            if run_id in self._cache:
+                state = self._cache[run_id]
+            else:
+                state_path = run_dir / "run_state.json"
+                if not state_path.exists():
+                    continue
+
+                try:
+                    state = json.loads(state_path.read_text(encoding="utf-8"))
+                except Exception as e:
+                    logger.warning("Failed to load run state %s: %s", run_dir, e)
+                    continue
+
+            if state is not None:
                 runs.append(
                     {
                         "run_id": state.get("run_id", run_dir.name),
@@ -190,8 +202,6 @@ class RunStateManager:
                         "timestamp": state.get("created_at"),
                     }
                 )
-            except Exception as e:
-                logger.warning("Failed to load run state %s: %s", run_dir, e)
 
         return runs
 


### PR DESCRIPTION
💡 What: Modified `RunStateManager.list_runs` in `swarm/api/services/run_state.py` to check `self._cache` for each candidate run before attempting to read `run_state.json` from disk.
🎯 Why: `list_runs` was reading and parsing `run_state.json` for every run in the candidate list (even if effectively paging), causing a bottleneck when many runs exist. Even with `scandir` optimization, the JSON parsing was expensive.
📊 Impact: Reduces `Path.read_text` and `json.loads` calls to 0 for runs already in the cache.
🔬 Measurement: Verified with a script (`reproduce_bottleneck.py`, not committed) that `Path.read_text` calls dropped from N to 0 for N cached runs. Existing tests passed.

---
*PR created automatically by Jules for task [13017024458165247866](https://jules.google.com/task/13017024458165247866) started by @EffortlessSteven*