### PR TITLE
⚡ Bolt: Unblock event loop in list_runs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+
+## 2026-01-23 - Unblocking Event Loop with asyncio.to_thread
+**Learning:** Synchronous file I/O operations (like `os.scandir` or `pathlib.Path.read_text`) in `RunStateManager.list_runs` block the main event loop when called from asynchronous FastAPI routes, degrading concurrency.
+**Action:** Wrap blocking I/O methods in `asyncio.to_thread` (introduced in Python 3.9) to offload execution to a separate thread, keeping the event loop responsive.

--- a/swarm/api/routes/runs_crud.py
+++ b/swarm/api/routes/runs_crud.py
@@ -82,7 +82,7 @@ async def list_runs(limit: int = 20):
         List of run summaries.
     """
     state_manager = get_state_manager()
-    runs = state_manager.list_runs(limit=limit)
+    runs = await state_manager.list_runs_async(limit=limit)
     return RunListResponse(runs=[RunSummary(**r) for r in runs])
 
 

--- a/swarm/api/services/run_state.py
+++ b/swarm/api/services/run_state.py
@@ -195,6 +195,14 @@ class RunStateManager:
 
         return runs
 
+    async def list_runs_async(self, limit: int = 20) -> List[Dict[str, Any]]:
+        """List recent runs asynchronously.
+
+        Wraps list_runs in a thread to prevent blocking the event loop
+        during file I/O operations (scandir, file reads).
+        """
+        return await asyncio.to_thread(self.list_runs, limit=limit)
+
 
 # Global state manager (initialized on first use)
 _state_manager: Optional[RunStateManager] = None

--- a/tests/test_run_state_manager.py
+++ b/tests/test_run_state_manager.py
@@ -1,0 +1,40 @@
+import asyncio
+import unittest
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from swarm.api.services.run_state import RunStateManager
+
+
+class TestRunStateManager(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.runs_root = Path(self.temp_dir.name)
+        self.manager = RunStateManager(self.runs_root)
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_list_runs_async_calls_list_runs(self):
+        """Test that list_runs_async calls list_runs."""
+        with patch.object(self.manager, "list_runs", return_value=[]) as mock_list_runs:
+            async def run_test():
+                await self.manager.list_runs_async(limit=10)
+
+            asyncio.run(run_test())
+            mock_list_runs.assert_called_once_with(limit=10)
+
+    def test_list_runs_async_returns_correct_data(self):
+        """Test that list_runs_async returns data from list_runs."""
+        expected_data = [{"run_id": "test-1"}]
+        with patch.object(self.manager, "list_runs", return_value=expected_data):
+            async def run_test():
+                result = await self.manager.list_runs_async(limit=10)
+                return result
+
+            result = asyncio.run(run_test())
+            self.assertEqual(result, expected_data)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
⚡ Bolt: Unblock event loop in list_runs

💡 What: Implemented `list_runs_async` in `RunStateManager` using `asyncio.to_thread` and updated the API route to use it.
🎯 Why: The previous implementation called the synchronous `list_runs` method from an async route, which blocked the event loop during file I/O operations (scandir, file reads). This degrades performance under load.
📊 Impact: Keeps the event loop responsive during run listing, allowing other requests to be processed concurrently.
🔬 Measurement: Verified with new unit tests `tests/test_run_state_manager.py` ensuring correct delegation and async execution. Existing tests pass.


---
*PR created automatically by Jules for task [13766716980886500678](https://jules.google.com/task/13766716980886500678) started by @EffortlessSteven*