### PR TITLE
🎨 Palette: Add clear button to search input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Toggle Visibility with Sibling Selectors
+**Learning:** Flow Studio uses `input:not(:placeholder-shown) ~ .element` to toggle visibility of helper elements (like shortcuts) based on input state without JS. This requires the helper element to appear *after* the input in the DOM.
+**Action:** When adding clear buttons or other input-dependent controls, place them after the input and use the general sibling selector `~` to control visibility based on placeholder state.

--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -1064,6 +1064,27 @@
     .search-input:not(:placeholder-shown) + .search-shortcut {
       display: none;
     }
+    .search-clear-btn {
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: none;
+      border: none;
+      color: #9ca3af;
+      font-size: 16px;
+      cursor: pointer;
+      padding: 0;
+      line-height: 1;
+      display: none;
+      z-index: 10;
+    }
+    .search-clear-btn:hover {
+      color: #4b5563;
+    }
+    .search-input:not(:placeholder-shown) ~ .search-clear-btn {
+      display: block;
+    }
     .search-icon {
       position: absolute;
       left: 10px;

--- a/swarm/tools/flow_studio_ui/fragments/10-header.html
+++ b/swarm/tools/flow_studio_ui/fragments/10-header.html
@@ -6,6 +6,7 @@
       <span class="search-icon" aria-hidden="true">&#128269;</span>
       <input type="text" id="search-input" class="search-input" placeholder="Search flows, steps, agents, artifacts..." autocomplete="off" aria-label="Search flows, steps, agents, and artifacts" data-uiid="flow_studio.header.search.input" />
       <kbd class="fs-kbd search-shortcut" aria-hidden="true">/</kbd>
+      <button id="search-clear" class="search-clear-btn" aria-label="Clear search" hidden data-uiid="flow_studio.header.search.clear">&times;</button>
       <div id="search-dropdown" class="search-dropdown" role="listbox" aria-label="Search results" data-uiid="flow_studio.header.search.results"></div>
     </div>
     </div>

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -24,6 +24,7 @@
       <span class="search-icon" aria-hidden="true">&#128269;</span>
       <input type="text" id="search-input" class="search-input" placeholder="Search flows, steps, agents, artifacts..." autocomplete="off" aria-label="Search flows, steps, agents, and artifacts" data-uiid="flow_studio.header.search.input" />
       <kbd class="fs-kbd search-shortcut" aria-hidden="true">/</kbd>
+      <button id="search-clear" class="search-clear-btn" aria-label="Clear search" hidden data-uiid="flow_studio.header.search.clear">&times;</button>
       <div id="search-dropdown" class="search-dropdown" role="listbox" aria-label="Search results" data-uiid="flow_studio.header.search.results"></div>
     </div>
     </div>
@@ -1700,6 +1701,27 @@
     .search-input:focus + .search-shortcut,
     .search-input:not(:placeholder-shown) + .search-shortcut {
       display: none;
+    }
+    .search-clear-btn {
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: none;
+      border: none;
+      color: #9ca3af;
+      font-size: 16px;
+      cursor: pointer;
+      padding: 0;
+      line-height: 1;
+      display: none;
+      z-index: 10;
+    }
+    .search-clear-btn:hover {
+      color: #4b5563;
+    }
+    .search-input:not(:placeholder-shown) ~ .search-clear-btn {
+      display: block;
     }
     .search-icon {
       position: absolute;
@@ -4793,9 +4815,16 @@ export function renderAgentUsage(container, usage, callbacks = {}) {
     list.className = "fs-text-body";
     list.style.lineHeight = "1.8";
     usage.forEach(u => {
-        const item = document.createElement("div");
+        const item = document.createElement("button");
         item.style.cursor = "pointer";
         item.style.padding = "2px 0";
+        item.style.background = "none";
+        item.style.border = "none";
+        item.style.textAlign = "left";
+        item.style.width = "100%";
+        item.style.fontFamily = "inherit";
+        item.style.fontSize = "inherit";
+        item.style.color = "inherit";
         item.innerHTML = renderAgentUsageItem(u.flow_title, u.step_title);
         item.title = `Click to navigate to ${u.flow}:${u.step}`;
         item.addEventListener("click", async () => {
@@ -4819,6 +4848,8 @@ export function renderAgentUsage(container, usage, callbacks = {}) {
         });
         item.addEventListener("mouseenter", () => { item.style.background = "#f3f4f6"; });
         item.addEventListener("mouseleave", () => { item.style.background = "transparent"; });
+        item.addEventListener("focus", () => { item.style.background = "#f3f4f6"; });
+        item.addEventListener("blur", () => { item.style.background = "transparent"; });
         list.appendChild(item);
     });
     container.appendChild(list);
@@ -5246,10 +5277,16 @@ export async function showStepDetails(data, callbacks = {}) {
         }
         else {
             stepAgents.forEach(agentKey => {
-                const agentLink = document.createElement("div");
+                const agentLink = document.createElement("button");
                 agentLink.style.cursor = "pointer";
                 agentLink.style.padding = "2px 0";
                 agentLink.style.color = "#3b82f6";
+                agentLink.style.background = "none";
+                agentLink.style.border = "none";
+                agentLink.style.textAlign = "left";
+                agentLink.style.width = "100%";
+                agentLink.style.fontFamily = "inherit";
+                agentLink.style.fontSize = "inherit";
                 agentLink.innerHTML = `<span class="mono">${escapeHtml(agentKey)}</span>`;
                 agentLink.title = `Click to view agent: ${agentKey}`;
                 agentLink.addEventListener("click", async () => {
@@ -5262,6 +5299,14 @@ export async function showStepDetails(data, callbacks = {}) {
                     agentLink.style.textDecoration = "underline";
                 });
                 agentLink.addEventListener("mouseleave", () => {
+                    agentLink.style.background = "transparent";
+                    agentLink.style.textDecoration = "none";
+                });
+                agentLink.addEventListener("focus", () => {
+                    agentLink.style.background = "#f3f4f6";
+                    agentLink.style.textDecoration = "underline";
+                });
+                agentLink.addEventListener("blur", () => {
                     agentLink.style.background = "transparent";
                     agentLink.style.textDecoration = "none";
                 });
@@ -8793,9 +8838,20 @@ export async function selectSearchResult(index) {
  */
 export function initSearchHandlers() {
     const searchInput = document.getElementById("search-input");
+    const searchClearBtn = document.getElementById("search-clear");
     const dropdown = document.getElementById("search-dropdown");
     if (!searchInput)
         return;
+    if (searchClearBtn) {
+        searchClearBtn.addEventListener("click", () => {
+            searchInput.value = "";
+            searchInput.focus();
+            if (state.searchDebounceTimer) {
+                clearTimeout(state.searchDebounceTimer);
+            }
+            closeSearchDropdown();
+        });
+    }
     searchInput.addEventListener("input", (e) => {
         if (state.searchDebounceTimer) {
             clearTimeout(state.searchDebounceTimer);
@@ -10133,7 +10189,10 @@ export function renderNoRuns() {
       <div class="fs-empty-icon" aria-hidden="true">\u{1F4C2}</div>
       <p class="fs-empty-title">No runs yet</p>
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
-      <code class="mono fs-empty-command">make demo-run</code>
+      <div class="fs-copy-command">
+        <code class="mono fs-empty-command">make demo-run</code>
+        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+      </div>
     </div>
   `;
 }

--- a/swarm/tools/flow_studio_ui/js/search.js
+++ b/swarm/tools/flow_studio_ui/js/search.js
@@ -151,9 +151,20 @@ export async function selectSearchResult(index) {
  */
 export function initSearchHandlers() {
     const searchInput = document.getElementById("search-input");
+    const searchClearBtn = document.getElementById("search-clear");
     const dropdown = document.getElementById("search-dropdown");
     if (!searchInput)
         return;
+    if (searchClearBtn) {
+        searchClearBtn.addEventListener("click", () => {
+            searchInput.value = "";
+            searchInput.focus();
+            if (state.searchDebounceTimer) {
+                clearTimeout(state.searchDebounceTimer);
+            }
+            closeSearchDropdown();
+        });
+    }
     searchInput.addEventListener("input", (e) => {
         if (state.searchDebounceTimer) {
             clearTimeout(state.searchDebounceTimer);

--- a/swarm/tools/flow_studio_ui/src/search.ts
+++ b/swarm/tools/flow_studio_ui/src/search.ts
@@ -163,9 +163,21 @@ export async function selectSearchResult(index: number): Promise<void> {
  */
 export function initSearchHandlers(): void {
   const searchInput = document.getElementById("search-input") as HTMLInputElement | null;
+  const searchClearBtn = document.getElementById("search-clear");
   const dropdown = document.getElementById("search-dropdown");
 
   if (!searchInput) return;
+
+  if (searchClearBtn) {
+    searchClearBtn.addEventListener("click", () => {
+      searchInput.value = "";
+      searchInput.focus();
+      if (state.searchDebounceTimer) {
+        clearTimeout(state.searchDebounceTimer);
+      }
+      closeSearchDropdown();
+    });
+  }
 
   searchInput.addEventListener("input", (e: Event) => {
     if (state.searchDebounceTimer) {

--- a/tests/test_flow_studio_ui_ids.py
+++ b/tests/test_flow_studio_ui_ids.py
@@ -579,6 +579,13 @@ class TestUIIDIntegrationExample:
             "Search input should have legacy id for backwards compatibility"
         )
 
+    def test_search_clear_button_has_uiid(self):
+        """Verify search clear button has data-uiid."""
+        html = get_flow_studio_html()
+        uiid = "flow_studio.header.search.clear"
+        pattern = f'data-uiid="{uiid}"'
+        assert pattern in html, f"Search clear button with data-uiid={uiid} should exist"
+
     def test_run_selector_css_selector(self):
         """Verify run selector dropdown can be reliably located by data-uiid.
 


### PR DESCRIPTION
💡 What: Added a clear button (×) to the Flow Studio search input.
🎯 Why: Users previously had to manually delete text to clear the search. This improves usability.
📸 Before/After: A clear button now appears when text is typed and disappears when empty.
♿ Accessibility: The button is keyboard accessible (when visible) and has an aria-label.


---
*PR created automatically by Jules for task [9632723559943548834](https://jules.google.com/task/9632723559943548834) started by @EffortlessSteven*