### PR TITLE
🎨 Palette: Add clear button to search input

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - CSS-Only Input Clear Button Visibility
+**Learning:** Flow Studio can utilize the `input:not(:placeholder-shown) ~ .clear-btn` CSS pattern to toggle visibility of helper elements without JavaScript state management. This requires using the general sibling selector (`~`) instead of adjacent (`+`) if other elements (like keyboard shortcuts) also depend on the input state.
+**Action:** When adding input helpers, position them after the input in the DOM and use `~` selectors to manage their visibility based on input state.

--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -1060,9 +1060,35 @@
       transform: translateY(-50%);
       pointer-events: none;
     }
-    .search-input:focus + .search-shortcut,
-    .search-input:not(:placeholder-shown) + .search-shortcut {
+    .search-input:focus ~ .search-shortcut,
+    .search-input:not(:placeholder-shown) ~ .search-shortcut {
       display: none;
+    }
+    .search-clear-btn {
+      display: none;
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: none;
+      border: none;
+      color: #9ca3af;
+      cursor: pointer;
+      padding: 0;
+      font-size: 16px;
+      line-height: 1;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      align-items: center;
+      justify-content: center;
+    }
+    .search-clear-btn:hover {
+      background: #f3f4f6;
+      color: #4b5563;
+    }
+    .search-input:not(:placeholder-shown) ~ .search-clear-btn {
+      display: flex;
     }
     .search-icon {
       position: absolute;

--- a/swarm/tools/flow_studio_ui/fragments/10-header.html
+++ b/swarm/tools/flow_studio_ui/fragments/10-header.html
@@ -5,6 +5,7 @@
     <div class="search-container" data-uiid="flow_studio.header.search">
       <span class="search-icon" aria-hidden="true">&#128269;</span>
       <input type="text" id="search-input" class="search-input" placeholder="Search flows, steps, agents, artifacts..." autocomplete="off" aria-label="Search flows, steps, agents, and artifacts" data-uiid="flow_studio.header.search.input" />
+      <button id="search-clear-btn" class="search-clear-btn" aria-label="Clear search" data-uiid="flow_studio.header.search.clear" hidden>×</button>
       <kbd class="fs-kbd search-shortcut" aria-hidden="true">/</kbd>
       <div id="search-dropdown" class="search-dropdown" role="listbox" aria-label="Search results" data-uiid="flow_studio.header.search.results"></div>
     </div>

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -23,6 +23,7 @@
     <div class="search-container" data-uiid="flow_studio.header.search">
       <span class="search-icon" aria-hidden="true">&#128269;</span>
       <input type="text" id="search-input" class="search-input" placeholder="Search flows, steps, agents, artifacts..." autocomplete="off" aria-label="Search flows, steps, agents, and artifacts" data-uiid="flow_studio.header.search.input" />
+      <button id="search-clear-btn" class="search-clear-btn" aria-label="Clear search" data-uiid="flow_studio.header.search.clear" hidden>×</button>
       <kbd class="fs-kbd search-shortcut" aria-hidden="true">/</kbd>
       <div id="search-dropdown" class="search-dropdown" role="listbox" aria-label="Search results" data-uiid="flow_studio.header.search.results"></div>
     </div>
@@ -1697,9 +1698,35 @@
       transform: translateY(-50%);
       pointer-events: none;
     }
-    .search-input:focus + .search-shortcut,
-    .search-input:not(:placeholder-shown) + .search-shortcut {
+    .search-input:focus ~ .search-shortcut,
+    .search-input:not(:placeholder-shown) ~ .search-shortcut {
       display: none;
+    }
+    .search-clear-btn {
+      display: none;
+      position: absolute;
+      right: 8px;
+      top: 50%;
+      transform: translateY(-50%);
+      background: none;
+      border: none;
+      color: #9ca3af;
+      cursor: pointer;
+      padding: 0;
+      font-size: 16px;
+      line-height: 1;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      align-items: center;
+      justify-content: center;
+    }
+    .search-clear-btn:hover {
+      background: #f3f4f6;
+      color: #4b5563;
+    }
+    .search-input:not(:placeholder-shown) ~ .search-clear-btn {
+      display: flex;
     }
     .search-icon {
       position: absolute;
@@ -4793,9 +4820,16 @@ export function renderAgentUsage(container, usage, callbacks = {}) {
     list.className = "fs-text-body";
     list.style.lineHeight = "1.8";
     usage.forEach(u => {
-        const item = document.createElement("div");
+        const item = document.createElement("button");
         item.style.cursor = "pointer";
         item.style.padding = "2px 0";
+        item.style.background = "none";
+        item.style.border = "none";
+        item.style.textAlign = "left";
+        item.style.width = "100%";
+        item.style.fontFamily = "inherit";
+        item.style.fontSize = "inherit";
+        item.style.color = "inherit";
         item.innerHTML = renderAgentUsageItem(u.flow_title, u.step_title);
         item.title = `Click to navigate to ${u.flow}:${u.step}`;
         item.addEventListener("click", async () => {
@@ -4819,6 +4853,8 @@ export function renderAgentUsage(container, usage, callbacks = {}) {
         });
         item.addEventListener("mouseenter", () => { item.style.background = "#f3f4f6"; });
         item.addEventListener("mouseleave", () => { item.style.background = "transparent"; });
+        item.addEventListener("focus", () => { item.style.background = "#f3f4f6"; });
+        item.addEventListener("blur", () => { item.style.background = "transparent"; });
         list.appendChild(item);
     });
     container.appendChild(list);
@@ -5246,10 +5282,16 @@ export async function showStepDetails(data, callbacks = {}) {
         }
         else {
             stepAgents.forEach(agentKey => {
-                const agentLink = document.createElement("div");
+                const agentLink = document.createElement("button");
                 agentLink.style.cursor = "pointer";
                 agentLink.style.padding = "2px 0";
                 agentLink.style.color = "#3b82f6";
+                agentLink.style.background = "none";
+                agentLink.style.border = "none";
+                agentLink.style.textAlign = "left";
+                agentLink.style.width = "100%";
+                agentLink.style.fontFamily = "inherit";
+                agentLink.style.fontSize = "inherit";
                 agentLink.innerHTML = `<span class="mono">${escapeHtml(agentKey)}</span>`;
                 agentLink.title = `Click to view agent: ${agentKey}`;
                 agentLink.addEventListener("click", async () => {
@@ -5262,6 +5304,14 @@ export async function showStepDetails(data, callbacks = {}) {
                     agentLink.style.textDecoration = "underline";
                 });
                 agentLink.addEventListener("mouseleave", () => {
+                    agentLink.style.background = "transparent";
+                    agentLink.style.textDecoration = "none";
+                });
+                agentLink.addEventListener("focus", () => {
+                    agentLink.style.background = "#f3f4f6";
+                    agentLink.style.textDecoration = "underline";
+                });
+                agentLink.addEventListener("blur", () => {
                     agentLink.style.background = "transparent";
                     agentLink.style.textDecoration = "none";
                 });
@@ -8794,8 +8844,19 @@ export async function selectSearchResult(index) {
 export function initSearchHandlers() {
     const searchInput = document.getElementById("search-input");
     const dropdown = document.getElementById("search-dropdown");
+    const clearBtn = document.getElementById("search-clear-btn");
     if (!searchInput)
         return;
+    if (clearBtn) {
+        clearBtn.addEventListener("click", () => {
+            if (state.searchDebounceTimer) {
+                clearTimeout(state.searchDebounceTimer);
+            }
+            searchInput.value = "";
+            searchInput.focus();
+            closeSearchDropdown();
+        });
+    }
     searchInput.addEventListener("input", (e) => {
         if (state.searchDebounceTimer) {
             clearTimeout(state.searchDebounceTimer);
@@ -10133,7 +10194,10 @@ export function renderNoRuns() {
       <div class="fs-empty-icon" aria-hidden="true">\u{1F4C2}</div>
       <p class="fs-empty-title">No runs yet</p>
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
-      <code class="mono fs-empty-command">make demo-run</code>
+      <div class="fs-copy-command">
+        <code class="mono fs-empty-command">make demo-run</code>
+        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+      </div>
     </div>
   `;
 }

--- a/swarm/tools/flow_studio_ui/js/search.js
+++ b/swarm/tools/flow_studio_ui/js/search.js
@@ -152,8 +152,19 @@ export async function selectSearchResult(index) {
 export function initSearchHandlers() {
     const searchInput = document.getElementById("search-input");
     const dropdown = document.getElementById("search-dropdown");
+    const clearBtn = document.getElementById("search-clear-btn");
     if (!searchInput)
         return;
+    if (clearBtn) {
+        clearBtn.addEventListener("click", () => {
+            if (state.searchDebounceTimer) {
+                clearTimeout(state.searchDebounceTimer);
+            }
+            searchInput.value = "";
+            searchInput.focus();
+            closeSearchDropdown();
+        });
+    }
     searchInput.addEventListener("input", (e) => {
         if (state.searchDebounceTimer) {
             clearTimeout(state.searchDebounceTimer);

--- a/swarm/tools/flow_studio_ui/src/search.ts
+++ b/swarm/tools/flow_studio_ui/src/search.ts
@@ -164,8 +164,20 @@ export async function selectSearchResult(index: number): Promise<void> {
 export function initSearchHandlers(): void {
   const searchInput = document.getElementById("search-input") as HTMLInputElement | null;
   const dropdown = document.getElementById("search-dropdown");
+  const clearBtn = document.getElementById("search-clear-btn");
 
   if (!searchInput) return;
+
+  if (clearBtn) {
+    clearBtn.addEventListener("click", () => {
+      if (state.searchDebounceTimer) {
+        clearTimeout(state.searchDebounceTimer);
+      }
+      searchInput.value = "";
+      searchInput.focus();
+      closeSearchDropdown();
+    });
+  }
 
   searchInput.addEventListener("input", (e: Event) => {
     if (state.searchDebounceTimer) {


### PR DESCRIPTION
💡 **What:** Added a "Clear Search" (X) button to the Flow Studio search input that appears when text is typed.
🎯 **Why:** Allows users to quickly clear their search query without repeatedly pressing Backspace.
📸 **Before/After:** (Verified via Playwright screenshot - button appears on typing, clears on click)
♿ **Accessibility:** The button has `aria-label="Clear search"` and is keyboard accessible. It uses CSS for visibility to avoid focus loss issues. Also synced unrelated a11y fixes (div -> button) from source to index.html during build.

---
*PR created automatically by Jules for task [15893024481316628054](https://jules.google.com/task/15893024481316628054) started by @EffortlessSteven*