### PR TITLE
🛡️ Sentinel: Fix path traversal in run events streaming

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-05 - Missing Path Validation in Event Streaming
+**Vulnerability:** Path traversal in `stream_run_events` endpoint via unvalidated `run_id`.
+**Learning:** `pathlib.Path` division operator (`/`) does not prevent path traversal (e.g., `base / "../secret"` resolves to parent). Explicit validation is required.
+**Prevention:** Always use `validate_path_component` for any user-supplied ID used in file paths, even when using `pathlib`.

--- a/swarm/api/routes/events.py
+++ b/swarm/api/routes/events.py
@@ -18,6 +18,8 @@ from typing import Any, AsyncGenerator, Dict, Optional
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
+from swarm.runtime.safe_paths import validate_path_component
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/runs", tags=["events"])
@@ -199,6 +201,8 @@ async def generate_run_events(
     Yields:
         SSE-formatted event strings.
     """
+    validate_path_component(run_id, "run_id")
+
     run_dir = runs_root / run_id
     events_file = run_dir / "events.jsonl"
     state_file = run_dir / "run_state.json"
@@ -353,6 +357,19 @@ async def stream_run_events(run_id: str, request: Request):
         event: run:completed
         data: {"run_id": "abc123", "status": "succeeded"}
     """
+    # Validate run_id to prevent path traversal
+    try:
+        validate_path_component(run_id, "run_id")
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_run_id",
+                "message": str(e),
+                "details": {"run_id": run_id},
+            },
+        )
+
     # Get runs root from spec manager
     from ..server import get_spec_manager
 

--- a/tests/test_api_events_traversal.py
+++ b/tests/test_api_events_traversal.py
@@ -1,0 +1,37 @@
+import pytest
+import asyncio
+from pathlib import Path
+from swarm.api.routes.events import generate_run_events
+
+@pytest.mark.anyio
+async def test_generate_run_events_traversal(tmp_path):
+    """Test that generate_run_events raises ValueError for path traversal."""
+    runs_root = tmp_path / "runs"
+    runs_root.mkdir()
+
+    # These should raise ValueError immediately
+    with pytest.raises(ValueError, match="run_id"):
+        gen = generate_run_events("../etc", runs_root)
+        await gen.__anext__()
+
+    with pytest.raises(ValueError, match="run_id"):
+        gen = generate_run_events("..", runs_root)
+        await gen.__anext__()
+
+    with pytest.raises(ValueError, match="run_id"):
+        gen = generate_run_events("foo/bar", runs_root)
+        await gen.__anext__()
+
+@pytest.mark.anyio
+async def test_generate_run_events_valid(tmp_path):
+    """Test that valid run_id works (at least starts)."""
+    runs_root = tmp_path / "runs"
+    runs_root.mkdir()
+
+    run_id = "valid-run"
+    (runs_root / run_id).mkdir()
+
+    gen = generate_run_events(run_id, runs_root)
+    # First event is 'connected'
+    event = await gen.__anext__()
+    assert "connected" in event


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix path traversal in run events streaming

🚨 Severity: CRITICAL
💡 Vulnerability: Path traversal in `stream_run_events` endpoint via unvalidated `run_id`. Attackers could potentially read arbitrary files by passing `../` sequences in `run_id` (e.g. `GET /api/runs/../secret/events`).
🎯 Impact: Unauthorized file access.
🔧 Fix: Added `validate_path_component` check for `run_id` in `stream_run_events` and `generate_run_events`.
✅ Verification: Added `tests/test_api_events_traversal.py` which attempts traversal and asserts `ValueError` is raised. Verified manually with `reproduce_traversal.py`.

---
*PR created automatically by Jules for task [16948219946703693177](https://jules.google.com/task/16948219946703693177) started by @EffortlessSteven*