### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in station preview

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-23 - Missing Path Traversal Validation in Station Preview
+**Vulnerability:** The `api_station_compile_preview` endpoint in `swarm/tools/flow_studio/routes/station_preview.py` lacked `validate_path_component` checks for `flow_id`, `step_id`, and `run_id`, allowing path traversal (e.g., `../../../ux_manifest`).
+**Learning:** While core API endpoints (e.g., in `swarm/api/routes/preview.py`) used `validate_path_component` correctly, the tool-specific endpoints in `swarm/tools/flow_studio` missed this validation. This inconsistency suggests that tool-related endpoints might be less rigorously reviewed or follow different patterns than the core API.
+**Prevention:** Always verify that ANY endpoint accepting file identifiers (run_id, flow_id, etc.) utilizes `validate_path_component` or equivalent validation before using them in file operations. Regard `swarm/tools` endpoints with equal scrutiny as `swarm/api`.

--- a/swarm/tools/flow_studio/routes/station_preview.py
+++ b/swarm/tools/flow_studio/routes/station_preview.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
 
+from swarm.runtime.safe_paths import validate_path_component
+
 from ..deps import get_state
 from ..state import FlowStudioState
 
@@ -24,6 +26,14 @@ async def api_station_compile_preview(
 ):
     if request is None:
         return JSONResponse({"error": "Request body required"}, status_code=400)
+
+    try:
+        validate_path_component(request.flow_id, "flow_id")
+        validate_path_component(request.step_id, "step_id")
+        if request.run_id:
+            validate_path_component(request.run_id, "run_id")
+    except ValueError as e:
+        return JSONResponse({"error": str(e)}, status_code=400)
 
     try:
         from swarm.spec.compiler import COMPILER_VERSION, SpecCompiler

--- a/tests/test_security_station_preview.py
+++ b/tests/test_security_station_preview.py
@@ -1,0 +1,77 @@
+from fastapi.testclient import TestClient
+from swarm.tools.flow_studio.app import create_app
+import pytest
+
+# Initialize client outside test to share app state if possible,
+# but create_app might need to be called per test or module.
+# Using module scope fixture is better if startup is heavy, but here it's fine.
+client = TestClient(create_app())
+
+def test_station_preview_path_traversal():
+    """Test that station preview endpoint rejects path traversal."""
+
+    # Test flow_id traversal
+    response = client.post(
+        "/api/station/compile-preview",
+        json={
+            "flow_id": "../../../ux_manifest",
+            "step_id": "step1",
+            "station_id": "station1",
+            "run_id": "default"
+        }
+    )
+    assert response.status_code == 400
+    error_msg = response.json()["error"]
+    assert "contains invalid characters" in error_msg or "traversal sequence" in error_msg
+    assert "flow_id" in error_msg
+
+    # Test step_id traversal
+    response = client.post(
+        "/api/station/compile-preview",
+        json={
+            "flow_id": "valid_flow",
+            "step_id": "../step1",
+            "station_id": "station1",
+            "run_id": "default"
+        }
+    )
+    assert response.status_code == 400
+    error_msg = response.json()["error"]
+    assert "contains invalid characters" in error_msg or "traversal sequence" in error_msg
+    assert "step_id" in error_msg
+
+    # Test run_id traversal
+    response = client.post(
+        "/api/station/compile-preview",
+        json={
+            "flow_id": "valid_flow",
+            "step_id": "step1",
+            "station_id": "station1",
+            "run_id": "../../etc"
+        }
+    )
+    assert response.status_code == 400
+    error_msg = response.json()["error"]
+    assert "contains invalid characters" in error_msg or "traversal sequence" in error_msg
+    assert "run_id" in error_msg
+
+def test_station_preview_valid_ids():
+    """Test that valid IDs are accepted (even if spec not found)."""
+
+    response = client.post(
+        "/api/station/compile-preview",
+        json={
+            "flow_id": "non_existent_flow",
+            "step_id": "step1",
+            "station_id": "station1",
+            "run_id": "valid-run-id"
+        }
+    )
+
+    # We expect 404 because the flow doesn't exist, but inputs are valid
+    assert response.status_code == 404
+    error_msg = response.json()["error"]
+    assert "Spec not found" in error_msg
+
+    # Ensure it's not a validation error
+    assert "contains invalid characters" not in error_msg


### PR DESCRIPTION
Fixes a path traversal vulnerability in the `api_station_compile_preview` endpoint by validating user input (`flow_id`, `step_id`, `run_id`) using `validate_path_component`. This ensures that these parameters cannot contain traversal sequences like `..` or `/`.

Verification:
- Added new test `tests/test_security_station_preview.py` which confirms that path traversal attempts are rejected with 400 Bad Request.
- Verified existing tests pass with `uv run pytest`.

---
*PR created automatically by Jules for task [829716069644137305](https://jules.google.com/task/829716069644137305) started by @EffortlessSteven*