### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS / Markdown Injection in stop reports

### DIFF
--- a/swarm/api/routes/runs_control.py
+++ b/swarm/api/routes/runs_control.py
@@ -12,6 +12,7 @@ Provides REST endpoints for:
 
 from __future__ import annotations
 
+import html
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -710,12 +711,14 @@ async def _write_stop_report(
     report_path = run_dir / "stop_report.md"
 
     # Build report content
+    # Sanitize inputs to prevent XSS/Markdown injection
+    reason = html.escape(stop_info.stop_reason) if stop_info.stop_reason else ""
     lines = [
         "# Stop Report",
         "",
         f"**Run ID:** {run_id}",
         f"**Stopped At:** {stop_info.stopped_at}",
-        f"**Reason:** {stop_info.stop_reason}",
+        f"**Reason:** {reason}",
         "",
         "## Execution State",
         "",
@@ -727,12 +730,14 @@ async def _write_stop_report(
 
     # Add routing intent if available
     if stop_info.last_routing_intent:
+        # Escape backticks to prevent breaking code block, and sanitize HTML
+        intent = html.escape(stop_info.last_routing_intent).replace("`", "'")
         lines.extend(
             [
                 "## Last Routing Intent",
                 "",
                 "```",
-                stop_info.last_routing_intent,
+                intent,
                 "```",
                 "",
             ]
@@ -747,7 +752,9 @@ async def _write_stop_report(
             ]
         )
         for call in stop_info.last_tool_calls:
-            lines.append(f"- `{call}`")
+            # Sanitize tool call paths
+            safe_call = html.escape(str(call))
+            lines.append(f"- `{safe_call}`")
         lines.append("")
 
     # Add open assumptions
@@ -759,7 +766,9 @@ async def _write_stop_report(
             ]
         )
         for assumption in stop_info.open_assumptions:
-            lines.append(f"- {assumption}")
+            # Sanitize assumptions
+            safe_assumption = html.escape(str(assumption))
+            lines.append(f"- {safe_assumption}")
         lines.append("")
 
     # Add completed steps if available


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Stored XSS / Markdown Injection in stop reports

🚨 Severity: HIGH
💡 Vulnerability: The `_write_stop_report` function in `swarm/api/routes/runs_control.py` was writing raw user input (e.g., `stop_reason`) into a Markdown file. This allowed an attacker to inject arbitrary HTML (XSS) or break out of Markdown code blocks.
🎯 Impact: If an admin or user views the `stop_report.md` in a web interface that renders Markdown/HTML, malicious scripts could be executed.
🔧 Fix: Inputs are now sanitized using `html.escape()` before being written to the file. Backticks in `last_routing_intent` are replaced to prevent code block breakout.
✅ Verification: Created a reproduction script `tests/reproduce_xss.py` which confirmed the vulnerability and then verified the fix. Ran existing tests `tests/test_flow_studio_fastapi_comprehensive.py` to ensure no regressions.

---
*PR created automatically by Jules for task [9400784495702733235](https://jules.google.com/task/9400784495702733235) started by @EffortlessSteven*