### PR TITLE
⚡ Bolt: Optimize list_runs endpoint with asyncio.to_thread

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+
+## 2026-01-23 - Async Route Blocking
+**Learning:** FastAPI async routes run on the main event loop. Synchronous I/O operations (like `os.scandir` in `list_runs`) block the entire server.
+**Action:** Always wrap synchronous I/O calls in `await asyncio.to_thread(...)` within async routes to maintain responsiveness.

--- a/swarm/api/routes/runs_crud.py
+++ b/swarm/api/routes/runs_crud.py
@@ -9,6 +9,7 @@ Provides REST endpoints for:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Optional
 
@@ -82,7 +83,8 @@ async def list_runs(limit: int = 20):
         List of run summaries.
     """
     state_manager = get_state_manager()
-    runs = state_manager.list_runs(limit=limit)
+    # Run blocking I/O in thread to avoid blocking event loop
+    runs = await asyncio.to_thread(state_manager.list_runs, limit=limit)
     return RunListResponse(runs=[RunSummary(**r) for r in runs])
 
 


### PR DESCRIPTION
💡 What: Wrapped `state_manager.list_runs` in `await asyncio.to_thread` within `swarm/api/routes/runs_crud.py`.
🎯 Why: The `list_runs` method performs synchronous file I/O (`os.scandir`, `os.path.exists`, `read_text`) which blocks the main asyncio event loop, causing unresponsiveness for other concurrent requests.
📊 Impact: Prevents the server from blocking during run listing, significantly improving concurrency and responsiveness, especially when the runs directory is large.
🔬 Measurement: Verified with a reproduction test (mocking slow I/O) that the endpoint correctly awaits the thread execution.

---
*PR created automatically by Jules for task [13800431118542662668](https://jules.google.com/task/13800431118542662668) started by @EffortlessSteven*