### PR TITLE
🛡️ Sentinel: [HIGH] Fix Stored XSS in run stop reports

### DIFF
--- a/swarm/api/routes/runs_control.py
+++ b/swarm/api/routes/runs_control.py
@@ -12,6 +12,7 @@ Provides REST endpoints for:
 
 from __future__ import annotations
 
+import html
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -715,7 +716,7 @@ async def _write_stop_report(
         "",
         f"**Run ID:** {run_id}",
         f"**Stopped At:** {stop_info.stopped_at}",
-        f"**Reason:** {stop_info.stop_reason}",
+        f"**Reason:** {html.escape(stop_info.stop_reason)}",
         "",
         "## Execution State",
         "",
@@ -727,12 +728,14 @@ async def _write_stop_report(
 
     # Add routing intent if available
     if stop_info.last_routing_intent:
+        # Sanitize routing intent to prevent markdown injection
+        sanitized_intent = stop_info.last_routing_intent.replace("```", "'''")
         lines.extend(
             [
                 "## Last Routing Intent",
                 "",
                 "```",
-                stop_info.last_routing_intent,
+                sanitized_intent,
                 "```",
                 "",
             ]
@@ -747,7 +750,9 @@ async def _write_stop_report(
             ]
         )
         for call in stop_info.last_tool_calls:
-            lines.append(f"- `{call}`")
+            # Escape code ticks to prevent markdown injection
+            sanitized_call = call.replace("`", "'")
+            lines.append(f"- `{sanitized_call}`")
         lines.append("")
 
     # Add open assumptions
@@ -759,7 +764,7 @@ async def _write_stop_report(
             ]
         )
         for assumption in stop_info.open_assumptions:
-            lines.append(f"- {assumption}")
+            lines.append(f"- {html.escape(assumption)}")
         lines.append("")
 
     # Add completed steps if available


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Stored XSS and Markdown Injection in run stop reports

🚨 Severity: HIGH
💡 Vulnerability: User-controlled input in `stop_run` endpoint (`reason`, `last_routing_intent`, etc.) was written directly to `stop_report.md` without sanitization. This allowed Stored XSS (if the markdown viewer renders HTML) and Markdown Injection (breaking out of code blocks).
🎯 Impact: Attackers could inject malicious scripts or spoof content in the forensic reports viewed by developers/operators.
🔧 Fix: Applied `html.escape` to `stop_reason` and `open_assumptions`. Sanitized backticks in `last_routing_intent` and `last_tool_calls`.
✅ Verification: Verified with a reproduction script that injected scripts are escaped and code blocks are preserved. Ran existing tests to ensure no regressions.

---
*PR created automatically by Jules for task [4026800579443128120](https://jules.google.com/task/4026800579443128120) started by @EffortlessSteven*