### PR TITLE
⚡ Bolt: [performance improvement] Optimize directory size calculation in runs_gc.py

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,15 +75,23 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+
+    def _scan(dir_path: str) -> None:
+        nonlocal total
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    try:
+                        if entry.is_file(follow_symlinks=False):
+                            total += entry.stat(follow_symlinks=False).st_size
+                        elif entry.is_dir(follow_symlinks=False):
+                            _scan(entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+
+    _scan(str(path))
     return total
 
 


### PR DESCRIPTION
💡 **What**: Optimized `get_dir_size` in `swarm/tools/runs_gc.py` by replacing `pathlib.Path.rglob("*")` with a custom recursive function using `os.scandir()`.
🎯 **Why**: `pathlib.Path.rglob` is significantly slower for large/deep directories because it creates `Path` objects for every file and performs separate `stat()` calls. `os.scandir` yields lightweight `os.DirEntry` objects that cache file attributes (like size), avoiding extra syscalls.
📊 **Impact**: Considerably speeds up `uv run swarm/tools/runs_gc.py list` and `prune` commands for deployments with tens of thousands of runs. *Note: This implementation explicitly ignores symlinks to prevent double-counting or infinite loops, which makes it safer for GC purposes.*
🔬 **Measurement**: 
1. `uv run swarm/tools/runs_gc.py list`
2. `uv run swarm/tools/runs_gc.py prune --dry-run`

---
*PR created automatically by Jules for task [14091984292844551590](https://jules.google.com/task/14091984292844551590) started by @EffortlessSteven*