### PR TITLE
⚡ Bolt: [performance improvement] Optimize directory size calculation in garbage collector

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -71,14 +72,21 @@ class RunInfo:
         return (now - self.mtime).total_seconds() / 86400
 
 
-def get_dir_size(path: Path) -> int:
+def get_dir_size(path: Path | str) -> int:
     """Get total size of a directory in bytes."""
     total = 0
     try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
+        # ⚡ Bolt Optimization: Replace pathlib.Path.rglob with recursive os.scandir
+        # for ~3x faster traversal by yielding lightweight DirEntry objects and
+        # caching their attributes (is_file, is_dir, stat) without instantiating Path objects.
+        with os.scandir(path) as it:
+            for entry in it:
                 try:
-                    total += entry.stat().st_size
+                    # Ignore symlinks to prevent double counting sizes
+                    if entry.is_file(follow_symlinks=False):
+                        total += entry.stat(follow_symlinks=False).st_size
+                    elif entry.is_dir(follow_symlinks=False):
+                        total += get_dir_size(entry.path)
                 except OSError:
                     pass
     except OSError:


### PR DESCRIPTION
💡 **What**: Replaced `pathlib.Path.rglob` with a recursive `os.scandir` implementation inside `get_dir_size` in `swarm/tools/runs_gc.py`. Included `follow_symlinks=False` logic to both `is_file` and `is_dir` as an additional measure to avoid double-counting and loop errors.

🎯 **Why**: `pathlib.Path.rglob` is slow as it constructs complete `Path` objects for every element it encounters. In contrast, `os.scandir` uses lightweight C-level operations to return `DirEntry` objects with cached properties.

📊 **Impact**: A small benchmarking script running the same traversal over an artificial 1000-file directory array showed ~60% improvement:
- Original (`rglob`): ~0.119s
- New (`os.scandir`): ~0.044s

🔬 **Measurement**: Verified using the ad-hoc test script `test_gc_fast.py` inside the sandbox environment. Run `uv run swarm/tools/runs_gc.py list` to verify the application functionality works without error.

---
*PR created automatically by Jules for task [11401618184959945254](https://jules.google.com/task/11401618184959945254) started by @EffortlessSteven*