### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Run Service

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-03-15 - Prevent Path Traversal in Run Service Handlers
+**Vulnerability:** `run_id` parameters were being passed directly to `run_service` methods without proper validation, opening the door to path traversal via methods like `get_events`, `cancel_run`, `stop_run`, and `mark_exemplar`.
+**Learning:** Even internal service handlers must explicitly validate string arguments used in paths or external service queries, as upstream layers may only do type checks rather than full security sanitization (i.e. `validate_path_component`).
+**Prevention:** Apply `validate_path_component` at the earliest point for all arguments deriving from URL parameters or user inputs prior to executing core logic or file system operations.

--- a/swarm/tools/flow_studio/services/run_service.py
+++ b/swarm/tools/flow_studio/services/run_service.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
+from swarm.runtime.safe_paths import validate_path_component
+
 
 def create_run_service(repo_root: Path) -> Optional[Any]:
     try:
@@ -90,6 +92,7 @@ def start_run(run_service: Any, flows: List[str], profile_id: Optional[str], bac
 
 
 def get_events(run_service: Any, run_id: str) -> List[Dict[str, Any]]:
+    validate_path_component(run_id, "run_id")
     events = run_service.get_events(run_id)
     return [
         {
@@ -106,6 +109,7 @@ def get_events(run_service: Any, run_id: str) -> List[Dict[str, Any]]:
 
 
 def cancel_run(run_service: Any, run_id: str) -> bool:
+    validate_path_component(run_id, "run_id")
     return bool(run_service.cancel_run(run_id))
 
 
@@ -119,6 +123,8 @@ def stop_run(run_service: Any, run_id: str, reason: str = "user_requested") -> D
         Dict with stop_report_path and stop_info forensics.
     """
     from datetime import datetime, timezone
+
+    validate_path_component(run_id, "run_id")
 
     # Use the underlying cancel mechanism
     cancelled = bool(run_service.cancel_run(run_id))
@@ -155,6 +161,7 @@ def stop_run(run_service: Any, run_id: str, reason: str = "user_requested") -> D
 
 
 def mark_exemplar(run_service: Any, run_id: str, is_exemplar: bool) -> bool:
+    validate_path_component(run_id, "run_id")
     return bool(run_service.mark_exemplar(run_id, is_exemplar))
 
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unvalidated `run_id` strings were passed into core run service functions (`get_events`, `cancel_run`, `stop_run`, `mark_exemplar`). If these derived directly from URL parameters or payloads, they could be exploited for path traversal.
🎯 **Impact:** Maliciously crafted `run_id`s (like `../../etc/passwd`) could potentially interact with or expose files outside the intended runs directory, depending on downstream database or filesystem implementations.
🔧 **Fix:** Imported and applied `validate_path_component` at the earliest point for the `run_id` argument in all susceptible service methods, enforcing strict alphanumeric character compliance.
✅ **Verification:** Verified fix visually using `git diff`, and ensured stability via `pytest tests/test_flow_studio_fastapi_comprehensive.py tests/test_flow_studio_backends_api.py`.

Journal entry also successfully updated.

---
*PR created automatically by Jules for task [4905495243412282279](https://jules.google.com/task/4905495243412282279) started by @EffortlessSteven*