### PR TITLE
⚡ Bolt: [performance improvement] Optimize directory size calculation in runs_gc.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+## 2026-03-22 - Use os.scandir Instead of pathlib.Path.rglob for Directory Sizes
+**Learning:** When recursively traversing directories to calculate metrics like total size, replacing `pathlib.Path.rglob` with `os.scandir` yields significantly better performance.
+**Action:** Use `os.scandir` instead of `pathlib.Path.rglob` when recursively iterating directories for high-performance needs, making sure to use `follow_symlinks=False` on `is_dir()` to avoid infinite loops, but not on `is_file()` to maintain symlink sizing behavior.

--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -73,16 +74,25 @@ class RunInfo:
 
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
+    # PERFORMANCE OPTIMIZATION (Bolt): Replaced path.rglob("*") with os.scandir for faster directory size calculation.
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+
+    def _scan(dir_path: str):
+        nonlocal total
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    if entry.is_dir(follow_symlinks=False):
+                        _scan(entry.path)
+                    elif entry.is_file():
+                        try:
+                            total += entry.stat().st_size
+                        except OSError:
+                            pass
+        except OSError:
+            pass
+
+    _scan(str(path))
     return total
 
 


### PR DESCRIPTION
💡 **What:** Replaced `pathlib.Path.rglob("*")` with a recursive `os.scandir()` loop in `swarm/tools/runs_gc.py`'s `get_dir_size` function.
🎯 **Why:** `pathlib.Path.rglob` is significantly slower for traversing large directory trees because it instantiates a `Path` object for every entry and performs separate `stat()` calls. `os.scandir` returns lightweight `DirEntry` objects, caching metadata at the OS level, thus reducing syscall overhead.
📊 **Impact:** Speeds up size calculation for directories (like `runs/`), especially those containing a very large number of files or deeply nested structures.
🔬 **Measurement:** Verify the optimization by running `uv run swarm/tools/runs_gc.py list` and observing reduced execution times and correct summary output.

---
*PR created automatically by Jules for task [2967569827053186720](https://jules.google.com/task/2967569827053186720) started by @EffortlessSteven*