### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL Injection Risk in Database Stats Endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - [SQL Injection Risk in Database Stats Endpoint]
+**Vulnerability:** A SQL injection vulnerability was found in the `/db/stats` endpoint (`swarm/api/routes/db.py`). The `safe_count` function constructs SQL queries using f-strings with a `table` parameter (`f"SELECT COUNT(*) FROM {table}"`) without validating the input.
+**Learning:** While the input currently comes from internal hardcoded table names ("runs", "steps", etc.), direct SQL string interpolation is an inherently dangerous pattern. If the API evolves and the `table` parameter becomes user-controlled, this would become an exploitable vulnerability.
+**Prevention:** Explicitly validate dynamic identifiers (like table names) against a strict allowlist of allowed values before executing the query, even for internal functions, to prevent regressions.

--- a/swarm/api/routes/db.py
+++ b/swarm/api/routes/db.py
@@ -242,6 +242,12 @@ async def get_db_stats():
 
         # Query counts from each table
         def safe_count(table: str) -> int:
+            # Explicit allowlist for dynamic table names to prevent SQL injection risks
+            allowed_tables = ["runs", "steps", "tool_calls", "file_changes", "events", "facts"]
+            if table not in allowed_tables:
+                logger.error(f"Attempted to query unallowed table: {table}")
+                return 0
+
             try:
                 result = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
                 return result[0] if result else 0


### PR DESCRIPTION
Fixes a SQL injection vulnerability pattern by adding an explicit allowlist check in the `safe_count` function in `swarm/api/routes/db.py`. Also adds a `sentinel.md` journal entry to log the finding.

---
*PR created automatically by Jules for task [7520097633094635477](https://jules.google.com/task/7520097633094635477) started by @EffortlessSteven*