### PR TITLE
⚡ Bolt: [performance improvement] optimize directory size calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+
+## 2024-03-24 - Faster Directory Traversal in Python
+**Learning:** When calculating the total size of a directory recursively, `pathlib.Path.rglob("*")` is slow because it creates many Path objects; using `os.scandir` recursively within a context manager is significantly faster.
+**Action:** Use `os.scandir` for performance-critical directory traversal and metric calculations in Python.

--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,15 +75,24 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+
+    # PERFORMANCE OPTIMIZATION (Bolt): Replaced pathlib.Path.rglob with os.scandir for faster directory traversal
+    def _scan_dir(dir_path: str) -> None:
+        nonlocal total
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    if entry.is_file():
+                        try:
+                            total += entry.stat().st_size
+                        except OSError:
+                            pass
+                    elif entry.is_dir(follow_symlinks=False):
+                        _scan_dir(entry.path)
+        except OSError:
+            pass
+
+    _scan_dir(str(path))
     return total
 
 


### PR DESCRIPTION
* 💡 **What:** Replaced `pathlib.Path.rglob("*")` with a custom recursive traversal using `os.scandir` inside `get_dir_size` in `swarm/tools/runs_gc.py`.
* 🎯 **Why:** `pathlib`'s recursive globbing constructs heavy Path objects for every single entity in a directory tree, which can cause significant latency when trying to quickly summarize sizes across large, deeply nested directories (e.g., thousands of runs/examples). `os.scandir` is highly optimized at the C-level and avoids instantiating heavy object representations for each file, leading to significant CPU/memory reductions for repetitive traversals.
* 📊 **Impact:** Expect dramatically faster file metric compilation, especially noticeable when dealing with thousands of runs/log items across a deeply nested folder structure.
* 🔬 **Measurement:** `uv run swarm/tools/runs_gc.py list` will execute much faster, especially over an extensive directory of simulated or recorded logs and metrics.

---
*PR created automatically by Jules for task [13504735185854962783](https://jules.google.com/task/13504735185854962783) started by @EffortlessSteven*