### PR TITLE
⚡ Bolt: [performance improvement] Replace rglob with os.scandir in runs_gc.py

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+
+## 2024-10-24 - Optimize recursive directory size calculation
+**Learning:** Using os.scandir instead of pathlib.Path.rglob is significantly faster when calculating total directory size.
+**Action:** Use os.scandir within a context manager when recursively calculating sizes.

--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -73,17 +74,26 @@ class RunInfo:
 
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
-    total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
-    return total
+
+    # PERFORMANCE OPTIMIZATION (Bolt): Using os.scandir instead of Path.rglob
+    # provides significantly faster directory traversal by returning cached stat results
+    def _scan(dir_path: str) -> int:
+        dir_total = 0
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    try:
+                        if entry.is_file():
+                            dir_total += entry.stat().st_size
+                        elif entry.is_dir(follow_symlinks=False):
+                            dir_total += _scan(entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+        return dir_total
+
+    return _scan(str(path))
 
 
 def get_run_info(run_id: str, run_path: Path, run_type: str) -> RunInfo:


### PR DESCRIPTION
💡 What: Replaced `pathlib.Path.rglob("*")` with `os.scandir()` within a context manager inside `get_dir_size()` in `swarm/tools/runs_gc.py`.

🎯 Why: `pathlib.Path.rglob()` instantiates Path objects for every single file and requires subsequent `stat()` calls to determine if an entry is a file. `os.scandir()` provides cached stat results, dramatically reducing file system calls during deep directory traversal, making recursive size calculations significantly faster.

📊 Impact: Substantially reduces file system overhead and execution time when calculating the total size of large run directories, which is critical for performance when managing 50k+ runs.

🔬 Measurement: Run `uv run swarm/tools/runs_gc.py list` on a directory with many runs and observe the execution time decrease compared to the previous implementation.

---
*PR created automatically by Jules for task [430981886142698929](https://jules.google.com/task/430981886142698929) started by @EffortlessSteven*