### PR TITLE
⚡ Bolt: [performance improvement] optimize directory size calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+## 2026-03-25 - Optimize Directory Size Calculation
+**Learning:** When calculating directory sizes across many runs (e.g. thousands of gc entries), `pathlib.Path.rglob` introduces significant overhead. `os.scandir` offers a much faster, lower-level alternative for recursive traversal.
+**Action:** Use `os.scandir` within a context manager (`with os.scandir(...) as it:`) and pass `follow_symlinks=False` to `is_dir()` to prevent infinite loops while preserving correct sizing behavior for symlinks.

--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -75,12 +76,17 @@ def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
     try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
+        # Optimization: os.scandir is significantly faster than pathlib.Path.rglob
+        # for traversing large directories as it caches file attributes.
+        with os.scandir(path) as it:
+            for entry in it:
+                if entry.is_dir(follow_symlinks=False):
+                    total += get_dir_size(Path(entry.path))
+                elif entry.is_file():
+                    try:
+                        total += entry.stat().st_size
+                    except OSError:
+                        pass
     except OSError:
         pass
     return total


### PR DESCRIPTION
### 💡 What:
Replaced `pathlib.Path.rglob("*")` with `os.scandir` in the recursive `get_dir_size` function inside `swarm/tools/runs_gc.py`.

### 🎯 Why:
`pathlib.Path.rglob` introduces significant overhead when recursively iterating through large directories because it instantiates a new `Path` object for every single file. Utilizing `os.scandir` directly with a recursive approach avoids this overhead and leverages cached file metadata, resulting in a significantly faster directory size calculation. This is a crucial bottleneck when dealing with potentially tens of thousands of past runs.

### 📊 Impact:
Significantly faster execution time when calculating directory sizes across many runs (e.g. thousands of gc entries). The optimization safely mimics the original implementation, preventing infinite loops by ignoring directory symlinks, while maintaining proper sizing calculations and avoiding permissions crashes.

### 🔬 Measurement:
Verified via `uv run swarm/tools/runs_gc.py list` ensuring runs still list correctly and calculate size accurately.

---
*PR created automatically by Jules for task [4611679826234647183](https://jules.google.com/task/4611679826234647183) started by @EffortlessSteven*