### PR TITLE
⚡ Bolt: [performance improvement] Optimize runs_gc.py get_dir_size

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -73,17 +74,25 @@ class RunInfo:
 
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
-    total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
-    return total
+
+    # Bolt: Replaced pathlib.Path.rglob with os.scandir for faster recursive traversal
+    def _get_size(p: str) -> int:
+        size = 0
+        try:
+            with os.scandir(p) as it:
+                for entry in it:
+                    try:
+                        if entry.is_file():
+                            size += entry.stat().st_size
+                        elif entry.is_dir(follow_symlinks=False):
+                            size += _get_size(entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+        return size
+
+    return _get_size(str(path))
 
 
 def get_run_info(run_id: str, run_path: Path, run_type: str) -> RunInfo:


### PR DESCRIPTION
💡 What: Replaced `pathlib.Path.rglob("*")` with `os.scandir` in `get_dir_size` function in `swarm/tools/runs_gc.py`.
🎯 Why: `rglob` can be slow for large directories because it yields `Path` objects which have instantiation overhead. `os.scandir` yields fast `DirEntry` objects which already contain cached `stat` information on most platforms, making recursive traversal and size summation much faster.
📊 Impact: Expected to reduce time taken to compute total run sizes, particularly noticeable when managing a large volume of runs. Benchmarks show a significant reduction in execution time for `get_dir_size`.
🔬 Measurement: Verify by executing `uv run swarm/tools/runs_gc.py list` and observing that it accurately reports total run sizes and finishes quickly.

---
*PR created automatically by Jules for task [325312339375382465](https://jules.google.com/task/325312339375382465) started by @EffortlessSteven*