### PR TITLE
⚡ Bolt: Optimize rglob to os.scandir in runs_gc.py

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,15 +75,27 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+
+    # PERFORMANCE OPTIMIZATION: Use os.scandir instead of Path.rglob()
+    # Path.rglob() instantiates Path objects for every single item and resolves full paths,
+    # which is very slow when listing large run directories. os.scandir() yields lightweight
+    # DirEntry objects with cached stats and is significantly faster.
+    def _scan(dir_path: str) -> None:
+        nonlocal total
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    if entry.is_dir(follow_symlinks=False):
+                        _scan(entry.path)
+                    elif entry.is_file():
+                        try:
+                            total += entry.stat().st_size
+                        except OSError:
+                            pass
+        except OSError:
+            pass
+
+    _scan(str(path))
     return total
 
 


### PR DESCRIPTION
Replaced `rglob` with `os.scandir` in `swarm/tools/runs_gc.py` to optimize directory size calculation.

---
*PR created automatically by Jules for task [12959794066578438094](https://jules.google.com/task/12959794066578438094) started by @EffortlessSteven*