### PR TITLE
⚡ Bolt: [performance improvement] optimize directory size calculation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+
+## 2024-03-26 - Directory Traversal Performance
+**Learning:** When calculating total directory size recursively, using `os.scandir` directly with an iterative stack is significantly faster than using `pathlib.Path.rglob` because it avoids building intermediate objects and fetches stats directly.
+**Action:** Use `os.scandir` instead of `Path.rglob` for recursive directory size calculations when performance is critical.

--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -73,16 +74,23 @@ class RunInfo:
 
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
+    # Optimization: os.scandir is significantly faster than Path.rglob for recursive size calculation
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+    dirs_to_scan = [str(path)]
+    while dirs_to_scan:
+        current_dir = dirs_to_scan.pop()
+        try:
+            with os.scandir(current_dir) as it:
+                for entry in it:
+                    try:
+                        if entry.is_file():
+                            total += entry.stat().st_size
+                        elif entry.is_dir(follow_symlinks=False):
+                            dirs_to_scan.append(entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
     return total
 
 


### PR DESCRIPTION
What: Replaced Path.rglob with os.scandir in get_dir_size in swarm/tools/runs_gc.py
Why: Path.rglob is slower for recursive directory traversal because it builds intermediate Path objects
Impact: Significantly faster directory size calculations
Measurement: Run `uv run swarm/tools/runs_gc.py list` to verify speedup

---
*PR created automatically by Jules for task [1604398619570949180](https://jules.google.com/task/1604398619570949180) started by @EffortlessSteven*