### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to selftest copy button

### DIFF
--- a/swarm/tools/flow_studio_ui/js/selftest_ui.js
+++ b/swarm/tools/flow_studio_ui/js/selftest_ui.js
@@ -234,7 +234,7 @@ export function renderSelftestStepModal(step) {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" data-uiid="flow_studio.selftest.copy" aria-label="Copy command" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/src/selftest_ui.ts
+++ b/swarm/tools/flow_studio_ui/src/selftest_ui.ts
@@ -257,7 +257,7 @@ export function renderSelftestStepModal(step: SelftestStep): void {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" data-uiid="flow_studio.selftest.copy" aria-label="Copy command" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>


### PR DESCRIPTION
What:
Added an `aria-label` attribute to the icon-only "Copy command" button in the selftest modal step details. Also added a standard `data-uiid` for automated testing.

Why:
The selftest modal copy button was an icon-only element without accessible text, causing screen readers to potentially ignore it or misread it, making the UI less inclusive.

Before/After:
Before: The button just had the clipboard icon character `📋` and a `title="Copy"`.
After: The button has `aria-label="Copy command"`, `title="Copy"`, and `data-uiid="flow_studio.selftest.copy"`.

Accessibility:
Added `aria-label="Copy command"` to ensure screen readers explicitly announce the purpose of the button to visually impaired users navigating via keyboard.

---
*PR created automatically by Jules for task [11348927201816978846](https://jules.google.com/task/11348927201816978846) started by @EffortlessSteven*