### PR TITLE
⚡ Bolt: Optimize recursive directory traversal in runs_gc.py

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -75,12 +76,23 @@ def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
     try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
+        # Bolt performance optimization: use os.scandir instead of path.rglob for recursive size calculation
+        # to reduce object creation overhead and redundant stat() calls.
+        stack = [str(path)]
+        while stack:
+            current_dir = stack.pop()
+            try:
+                with os.scandir(current_dir) as entries:
+                    for entry in entries:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(entry.path)
+                        elif entry.is_file():
+                            try:
+                                total += entry.stat().st_size
+                            except OSError:
+                                pass
+            except OSError:
+                pass
     except OSError:
         pass
     return total


### PR DESCRIPTION
What: Replaced `pathlib.Path.rglob("*")` with a stack-based `os.scandir()` loop in `get_dir_size()`. Retained safety mechanisms (e.g. inner `try/except OSError`) for concurrently deleted files and symlink checks.
Why: `path.rglob` is notoriously slow for large directory trees because it instantiates heavy `Path` objects and performs multiple internal operations per file. `os.scandir` acts as an extremely efficient iterator that provides lightweight `DirEntry` objects with cached `stat()` results, directly addressing a core optimization bottleneck in filesystem scripts.
Impact: Reduces memory allocation significantly by skipping `Path` object instantiation and dramatically reduces the number of underlying system calls during traversal, speeding up garbage collection metric calculation.
Measurement: Compare the execution time of `uv run swarm/tools/runs_gc.py list` before and after the change on a directory containing thousands of runs.

---
*PR created automatically by Jules for task [13170185865540738926](https://jules.google.com/task/13170185865540738926) started by @EffortlessSteven*