### PR TITLE
🎨 Palette: Add ARIA label to selftest copy button

### DIFF
--- a/swarm/tools/flow_studio_ui/js/selftest_ui.js
+++ b/swarm/tools/flow_studio_ui/js/selftest_ui.js
@@ -234,7 +234,7 @@ export function renderSelftestStepModal(step) {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" aria-label="Copy command to clipboard" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/src/selftest_ui.ts
+++ b/swarm/tools/flow_studio_ui/src/selftest_ui.ts
@@ -257,7 +257,7 @@ export function renderSelftestStepModal(step: SelftestStep): void {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" aria-label="Copy command to clipboard" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>


### PR DESCRIPTION
🎨 Palette: Add ARIA label to selftest copy button

💡 What: Added an `aria-label="Copy command to clipboard"` to the icon-only copy button within the selftest step modal (`swarm/tools/flow_studio_ui/src/selftest_ui.ts`).

🎯 Why: To improve accessibility for screen reader users by providing an explicit and descriptive accessible name for a button that only visually displays a clipboard emoji (📋).

📸 Before/After: Before, the button lacked an accessible name, making its function unclear to assistive technologies. After, the button is clearly announced as "Copy command to clipboard". Visually, there is no change.

♿ Accessibility: Ensures compliance with WCAG guidelines for non-text content and controls by providing a programmatic label for an icon-only interactive element.

---
*PR created automatically by Jules for task [11341912581482018925](https://jules.google.com/task/11341912581482018925) started by @EffortlessSteven*