### PR TITLE
🎨 Palette: [UX improvement] Add aria-expanded to Boundary Review toggle

### DIFF
--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -309,6 +309,7 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", String(isExpanded));
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/pnpm-lock.yaml
+++ b/swarm/tools/flow_studio_ui/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.3: {}

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -345,6 +345,7 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", String(isExpanded));
     }
   });
 }


### PR DESCRIPTION
What: Added `aria-expanded` attribute to the Boundary Review toggle button and synchronized its state via the click handler in `boundary_review.ts`.
Why: The toggle button lacked state communication, meaning screen reader users wouldn't know if the boundary review sections were expanded or collapsed.
Before/After: Before, the button had no `aria-expanded` attribute. After, it accurately reflects the `isExpanded` state. (Screenshots/Video attached in the verification step)
Accessibility: Improves keyboard and screen reader accessibility by providing crucial state information for the collapsible boundary review sections, complying with WCAG guidelines.

---
*PR created automatically by Jules for task [11919932364406935227](https://jules.google.com/task/11919932364406935227) started by @EffortlessSteven*