### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon buttons

### DIFF
--- a/swarm/tools/flow_studio_ui/js/selftest_ui.js
+++ b/swarm/tools/flow_studio_ui/js/selftest_ui.js
@@ -234,7 +234,7 @@ export function renderSelftestStepModal(step) {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy" aria-label="Copy command">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/js/ui_fragments.js
+++ b/swarm/tools/flow_studio_ui/js/ui_fragments.js
@@ -21,7 +21,7 @@ export function renderNoRuns() {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy demo command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;

--- a/swarm/tools/flow_studio_ui/src/selftest_ui.ts
+++ b/swarm/tools/flow_studio_ui/src/selftest_ui.ts
@@ -257,7 +257,7 @@ export function renderSelftestStepModal(step: SelftestStep): void {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy" aria-label="Copy command">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/src/ui_fragments.ts
+++ b/swarm/tools/flow_studio_ui/src/ui_fragments.ts
@@ -24,7 +24,7 @@ export function renderNoRuns(): string {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy demo command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add ARIA labels to icon buttons

What: Added aria-label="Copy command" to selftest-command-copy-btn in `selftest_ui.ts` and aria-label="Copy demo command" to fs-icon-button copy-button in `ui_fragments.ts`.
Why: Screen readers need an accessible name to correctly announce these icon-only copy buttons.
Before/After: Before, screen readers would simply say "button" or read the unicode clipboard icon without context. After, they announce "Copy command" or "Copy demo command".
Accessibility: Improves WCAG compliance by providing explicit aria-labels for buttons that lack visible, descriptive text.

---
*PR created automatically by Jules for task [10074497019704118683](https://jules.google.com/task/10074497019704118683) started by @EffortlessSteven*