### PR TITLE
⚡ Bolt: [performance improvement] optimize get_dir_size with os.scandir

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -73,17 +74,26 @@ class RunInfo:
 
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
-    total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
-    return total
+
+    # Bolt optimization: os.scandir is significantly faster than pathlib.Path.rglob
+    # because it reduces intermediate Path object creation and redundant stat() calls.
+    def _get_size(dir_path: str) -> int:
+        total = 0
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    try:
+                        if entry.is_file():
+                            total += entry.stat().st_size
+                        elif entry.is_dir(follow_symlinks=False):
+                            total += _get_size(entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+        return total
+
+    return _get_size(str(path))
 
 
 def get_run_info(run_id: str, run_path: Path, run_type: str) -> RunInfo:


### PR DESCRIPTION
What: Replaced `pathlib.Path.rglob("*")` with `os.scandir` in `get_dir_size`.
Why: `pathlib.Path.rglob` yields `Path` objects, and performing subsequent `is_file()` and `stat()` calls can result in redundant syscalls. `os.scandir` yields `DirEntry` objects that expose file types via `d_type` and cache `stat()` results.
Impact: Significantly reduces file system syscalls, intermediate `Path` object creation, and overall execution time for directory size calculation in garbage collection.
Measurement: Time `uv run swarm/tools/runs_gc.py list` before and after this change.

---
*PR created automatically by Jules for task [7378482861281223178](https://jules.google.com/task/7378482861281223178) started by @EffortlessSteven*