### PR TITLE
⚡ Bolt: Optimize directory size calculation with os.scandir

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -73,16 +74,23 @@ class RunInfo:
 
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
+    # ⚡ Bolt: Replaced rglob with os.scandir for faster directory traversal
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+    stack = [str(path)]
+    while stack:
+        current_path = stack.pop()
+        try:
+            with os.scandir(current_path) as it:
+                for entry in it:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(entry.path)
+                        elif entry.is_file():
+                            total += entry.stat().st_size
+                    except OSError:
+                        pass
+        except OSError:
+            pass
     return total
 
 


### PR DESCRIPTION
💡 What: Replaced `pathlib.Path.rglob("*")` with an iterative `os.scandir` implementation in `get_dir_size` within `swarm/tools/runs_gc.py`.

🎯 Why: `Path.rglob` is significantly slower because it instantiates `Path` objects for every file and directory, and it requires an extra `.stat()` call to get file sizes. `os.scandir` caches `DirEntry` attributes (like `is_dir()` and `is_file()`) natively, drastically reducing system call overhead and object creation during deep directory traversals.

📊 Impact: Reduces disk I/O and CPU overhead during garbage collection. Depending on the size of the `runs` directory, traversing hundreds or thousands of files is demonstrably faster.

🔬 Measurement: Run `uv run swarm/tools/runs_gc.py list` on a populated directory and compare execution times.

---
*PR created automatically by Jules for task [13863536519901190946](https://jules.google.com/task/13863536519901190946) started by @EffortlessSteven*