### PR TITLE
🎨 Palette: [UX improvement] Add missing ARIA labels to buttons

### DIFF
--- a/swarm/tools/flow_studio_ui/js/ui_fragments.js
+++ b/swarm/tools/flow_studio_ui/js/ui_fragments.js
@@ -21,7 +21,7 @@ export function renderNoRuns() {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy demo command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;

--- a/swarm/tools/flow_studio_ui/src/ui_fragments.ts
+++ b/swarm/tools/flow_studio_ui/src/ui_fragments.ts
@@ -24,7 +24,7 @@ export function renderNoRuns(): string {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy demo command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;


### PR DESCRIPTION
💡 What: Added an `aria-label` to the copy button in the "No runs yet" empty state of the Flow Studio UI.
🎯 Why: The copy button is an icon-only button and requires an ARIA label for screen reader accessibility to clearly describe its purpose.
📸 Before/After: The button previously had a `title` attribute but no `aria-label`. Now it has an `aria-label` explicitly reading "Copy demo command".
♿ Accessibility: Improves keyboard and screen reader accessibility by providing a clear, text-based accessible name for an interactive icon-only element.

---
*PR created automatically by Jules for task [12407474213889815405](https://jules.google.com/task/12407474213889815405) started by @EffortlessSteven*