### PR TITLE
⚡ Bolt: [performance improvement] Optimize directory size calculation in runs_gc.py

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -75,10 +76,15 @@ def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
     try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
+        # Performance optimization: os.scandir is significantly faster than Path.rglob
+        # as it avoids object creation overhead and redundant stat calls.
+        with os.scandir(path) as it:
+            for entry in it:
                 try:
-                    total += entry.stat().st_size
+                    if entry.is_dir(follow_symlinks=False):
+                        total += get_dir_size(Path(entry.path))
+                    elif entry.is_file():
+                        total += entry.stat().st_size
                 except OSError:
                     pass
     except OSError:


### PR DESCRIPTION
What: Replaced Path.rglob("*") with a recursive os.scandir implementation for calculating directory sizes in runs_gc.py.
Why: Path.rglob creates a Path object and performs redundant stat calls for every file. os.scandir is a well-documented performance optimization that caches file attributes during directory traversal, significantly reducing overhead, especially for large directories with many files.
Impact: Substantially reduces the execution time of the `get_dir_size` function, leading to faster execution of the `runs_gc.py` script overall.
Measurement: Compare execution times of `uv run swarm/tools/runs_gc.py list` before and after the change on a directory containing thousands of run files.

---
*PR created automatically by Jules for task [18288482996739185335](https://jules.google.com/task/18288482996739185335) started by @EffortlessSteven*