### PR TITLE
⚡ Bolt: [performance improvement] optimize directory size calculation

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,15 +75,24 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+
+    # Optimization: os.scandir is significantly faster than Path.rglob because it avoids Path object creation overhead and caches stat calls.
+    def _scan(p: str) -> None:
+        nonlocal total
+        try:
+            with os.scandir(p) as it:
+                for entry in it:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            _scan(entry.path)
+                        elif entry.is_file():
+                            total += entry.stat().st_size
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+
+    _scan(str(path))
     return total
 
 


### PR DESCRIPTION
What: Replace `pathlib.Path.rglob` with `os.scandir` in `get_dir_size`.
Why: `Path.rglob` creates expensive `Path` objects and often does not cache `stat` calls, making it very slow for large nested directories. `os.scandir` leverages `DirEntry` caching and avoids object creation overhead.
Impact: Significantly faster garbage collection runs when measuring and pruning large numbers of old runs or fragments.
Measurement: Time `uv run swarm/tools/runs_gc.py list` before and after to verify the speedup on a directory with many runs.

---
*PR created automatically by Jules for task [1620702404125469326](https://jules.google.com/task/1620702404125469326) started by @EffortlessSteven*