### PR TITLE
⚡ Bolt: Optimize directory size calculation in runs_gc.py using os.scandir

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,13 +75,26 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
+    # Performance optimization: use os.scandir instead of Path.rglob to avoid
+    # overhead from object creation and separate stat() calls.
     try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
+
+        def scan_dir(dir_path: Path):
+            nonlocal total
+            try:
+                with os.scandir(dir_path) as it:
+                    for entry in it:
+                        try:
+                            if entry.is_file():
+                                total += entry.stat().st_size
+                            elif entry.is_dir(follow_symlinks=False):
+                                scan_dir(Path(entry.path))
+                        except OSError:
+                            pass
+            except OSError:
+                pass
+
+        scan_dir(path)
     except OSError:
         pass
     return total


### PR DESCRIPTION
⚡ Bolt: Optimize directory size calculation in runs_gc.py using os.scandir

**What:** 
Replaced `pathlib.Path.rglob("*")` with a custom recursive traversal using `os.scandir()` in the `get_dir_size` function of `swarm/tools/runs_gc.py`.

**Why:** 
`Path.rglob("*")` creates full `pathlib.Path` objects for every discovered file and then requires an additional `stat()` call to get the size. `os.scandir` is a well-known Python optimization that yields lightweight `DirEntry` objects with cached attributes, avoiding redundant system calls and reducing memory allocation overhead, making directory traversal much faster.

**Impact:** 
This change reduces the overhead required to aggregate the size of the `runs` directory, directly speeding up the GC tool commands like `list` and `prune`, especially as the number of persisted run artifacts grows.

**Measurement:** 
Run `uv run swarm/tools/runs_gc.py list` against a populated runs directory and measure execution time. The new logic behaves identically (skipping directory symlinks while including file symlinks and handling OS errors securely).

---
*PR created automatically by Jules for task [8628727227694466539](https://jules.google.com/task/8628727227694466539) started by @EffortlessSteven*