### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to copy buttons

### DIFF
--- a/swarm/tools/flow_studio_ui/js/selftest_ui.js
+++ b/swarm/tools/flow_studio_ui/js/selftest_ui.js
@@ -234,7 +234,7 @@ export function renderSelftestStepModal(step) {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy" aria-label="Copy command">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/src/selftest_ui.ts
+++ b/swarm/tools/flow_studio_ui/src/selftest_ui.ts
@@ -257,7 +257,7 @@ export function renderSelftestStepModal(step: SelftestStep): void {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy" aria-label="Copy command">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>


### PR DESCRIPTION
What: Added an `aria-label` attribute to the icon-only copy button in the selftest UI.
Why: Icon-only buttons without accessible names are invisible or confusing to screen reader users, breaking accessibility.
Before/After: The visual design is completely unchanged. The button now has an `aria-label="Copy command"` which allows screen readers to properly announce its function.
Accessibility: Improved compliance with WCAG 4.1.2 (Name, Role, Value) by giving an interactive control an accessible name.

---
*PR created automatically by Jules for task [15024333969717078538](https://jules.google.com/task/15024333969717078538) started by @EffortlessSteven*