### PR TITLE
⚡ Bolt: Replace rglob with os.scandir for performance

### DIFF
--- a/swarm/config/packs/resolver.py
+++ b/swarm/config/packs/resolver.py
@@ -135,8 +135,8 @@ class PackResolver:
             value, source, path = self._resolve_value(
                 cli_key=f"features.{field}",
                 env_key=f"SWARM_FEATURE_{field.upper()}",
-                repo_getter=lambda p, f=field: (getattr(p.features, f, None) if p else None),
-                baseline_getter=lambda p, f=field: (getattr(p.features, f, None) if p else None),
+                repo_getter=lambda p, f=field: getattr(p.features, f, None) if p else None,
+                baseline_getter=lambda p, f=field: getattr(p.features, f, None) if p else None,
             )
             if value is not None:
                 result[field] = value
@@ -158,8 +158,8 @@ class PackResolver:
             value, source, path = self._resolve_value(
                 cli_key=f"runtime.{field}",
                 env_key=f"SWARM_{field.upper()}",
-                repo_getter=lambda p, f=field: (getattr(p.runtime, f, None) if p else None),
-                baseline_getter=lambda p, f=field: (getattr(p.runtime, f, None) if p else None),
+                repo_getter=lambda p, f=field: getattr(p.runtime, f, None) if p else None,
+                baseline_getter=lambda p, f=field: getattr(p.runtime, f, None) if p else None,
             )
             if value is not None:
                 result[field] = value

--- a/swarm/runtime/resilient_db.py
+++ b/swarm/runtime/resilient_db.py
@@ -391,16 +391,18 @@ class ResilientStatsDB:
     def get_routing_decision_summary_safe(self, run_id: str) -> Dict[str, Any]:
         """Get routing decision summary safely, returning empty dict on error."""
         return self._safe_operation(
-            lambda: self._db.get_routing_decision_summary(run_id)
-            if self._db
-            else {
-                "total_decisions": 0,
-                "by_decision": {},
-                "by_routing_mode": {},
-                "by_routing_source": {},
-                "needs_human_count": 0,
-                "terminations": 0,
-            },
+            lambda: (
+                self._db.get_routing_decision_summary(run_id)
+                if self._db
+                else {
+                    "total_decisions": 0,
+                    "by_decision": {},
+                    "by_routing_mode": {},
+                    "by_routing_source": {},
+                    "needs_human_count": 0,
+                    "terminations": 0,
+                }
+            ),
             f"get_routing_decision_summary({run_id})",
             {
                 "total_decisions": 0,
@@ -427,9 +429,11 @@ class ResilientStatsDB:
     def rebuild_from_events_safe(self, run_id: str) -> Dict[str, Any]:
         """Rebuild projection for a run safely."""
         return self._safe_operation(
-            lambda: self._db.rebuild_from_events(run_id, self.config.runs_dir)
-            if self._db
-            else {"success": False, "error": "DB not initialized"},
+            lambda: (
+                self._db.rebuild_from_events(run_id, self.config.runs_dir)
+                if self._db
+                else {"success": False, "error": "DB not initialized"}
+            ),
             f"rebuild_from_events({run_id})",
             {"success": False, "error": "Operation failed"},
         )

--- a/swarm/tools/flow_studio/routes/runs.py
+++ b/swarm/tools/flow_studio/routes/runs.py
@@ -241,7 +241,10 @@ async def api_stop_run(run_id: str, state: FlowStudioState = Depends(get_state))
 
         if not result.get("success", False):
             return JSONResponse(
-                {"error": result.get("message", "Run not found or already completed"), "run_id": run_id},
+                {
+                    "error": result.get("message", "Run not found or already completed"),
+                    "run_id": run_id,
+                },
                 status_code=404,
             )
 

--- a/swarm/tools/lint_routing_fields.py
+++ b/swarm/tools/lint_routing_fields.py
@@ -149,8 +149,10 @@ NEW_ROUTING_VALIDATION_PATTERNS = [
     (
         r"^\s*[-*]?\s*routing:\s*([A-Z][A-Z_]+)\s*(?:,|$|\()",
         "routing_field_yaml",
-        lambda m: m.group(1) not in VALID_ROUTING_DECISIONS
-        and m.group(1) not in {"MERGE", "SKIP", "NULL"},
+        lambda m: (
+            m.group(1) not in VALID_ROUTING_DECISIONS
+            and m.group(1) not in {"MERGE", "SKIP", "NULL"}
+        ),
         "invalid routing value (must be CONTINUE|DETOUR|INJECT_FLOW|INJECT_NODES|EXTEND_GRAPH)",
     ),
     # routing field in JSON format

--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,13 +75,24 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
+    # Optimization: os.scandir is faster than pathlib.Path.rglob since it avoids
+    # creating Path objects and caches stat results.
     try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
+        stack = [str(path)]
+        while stack:
+            current_dir = stack.pop()
+            try:
+                with os.scandir(current_dir) as it:
+                    for entry in it:
+                        try:
+                            if entry.is_dir(follow_symlinks=False):
+                                stack.append(entry.path)
+                            elif entry.is_file():
+                                total += entry.stat().st_size
+                        except OSError:
+                            pass
+            except OSError:
+                pass
     except OSError:
         pass
     return total

--- a/tests/test_boundary_secret_scanning.py
+++ b/tests/test_boundary_secret_scanning.py
@@ -1,8 +1,9 @@
-import pytest
-from pathlib import Path
 from unittest.mock import MagicMock
-from swarm.runtime.boundary_enforcement import BoundaryScanner, WorkspaceState, ViolationType
+
+import pytest
+from swarm.runtime.boundary_enforcement import BoundaryScanner, ViolationType, WorkspaceState
 from swarm.runtime.workspace import Workspace
+
 
 @pytest.fixture
 def mock_workspace(tmp_path):
@@ -10,6 +11,7 @@ def mock_workspace(tmp_path):
     workspace.root.return_value = tmp_path
     workspace.is_shadow.return_value = False
     return workspace
+
 
 def test_detects_secret_in_file_content(mock_workspace, tmp_path):
     """Test that BoundaryScanner detects secrets in file content."""
@@ -19,16 +21,10 @@ def test_detects_secret_in_file_content(mock_workspace, tmp_path):
     secret_file.write_text('api_client = Client(api_key="sk-ant-test-key-12345")')
 
     # State with the changed file
-    state = WorkspaceState(
-        timestamp="2024-01-01T00:00:00Z",
-        changed_files={"my_script.py"}
-    )
+    state = WorkspaceState(timestamp="2024-01-01T00:00:00Z", changed_files={"my_script.py"})
 
     scanner = BoundaryScanner(
-        workspace=mock_workspace,
-        step_id="step-1",
-        repo_root=tmp_path,
-        baseline_state=None
+        workspace=mock_workspace, step_id="step-1", repo_root=tmp_path, baseline_state=None
     )
 
     violations = scanner.scan(current_state=state)
@@ -40,6 +36,7 @@ def test_detects_secret_in_file_content(mock_workspace, tmp_path):
     assert "sk-ant-" in secret_violations[0].detail
     assert "Anthropic API Key" in secret_violations[0].detail
 
+
 def test_skips_binary_files(mock_workspace, tmp_path):
     """Test that BoundaryScanner skips binary files even if they contain pattern."""
     # Create a binary file (invalid utf-8) that happens to have the bytes for a key
@@ -48,16 +45,10 @@ def test_skips_binary_files(mock_workspace, tmp_path):
     content = b"some binary data \xff " + b"sk-ant-test-key"
     binary_file.write_bytes(content)
 
-    state = WorkspaceState(
-        timestamp="2024-01-01T00:00:00Z",
-        changed_files={"data.bin"}
-    )
+    state = WorkspaceState(timestamp="2024-01-01T00:00:00Z", changed_files={"data.bin"})
 
     scanner = BoundaryScanner(
-        workspace=mock_workspace,
-        step_id="step-1",
-        repo_root=tmp_path,
-        baseline_state=None
+        workspace=mock_workspace, step_id="step-1", repo_root=tmp_path, baseline_state=None
     )
 
     violations = scanner.scan(current_state=state)
@@ -66,22 +57,17 @@ def test_skips_binary_files(mock_workspace, tmp_path):
     secret_violations = [v for v in violations if v.type == ViolationType.SECRET_EXPOSURE]
     assert len(secret_violations) == 0
 
+
 def test_skips_large_files(mock_workspace, tmp_path):
     """Test that BoundaryScanner skips files larger than limit."""
     large_file = tmp_path / "large.txt"
     # Create 1.1MB file
     large_file.write_text("a" * (1024 * 1024 + 100) + "sk-ant-test-key")
 
-    state = WorkspaceState(
-        timestamp="2024-01-01T00:00:00Z",
-        changed_files={"large.txt"}
-    )
+    state = WorkspaceState(timestamp="2024-01-01T00:00:00Z", changed_files={"large.txt"})
 
     scanner = BoundaryScanner(
-        workspace=mock_workspace,
-        step_id="step-1",
-        repo_root=tmp_path,
-        baseline_state=None
+        workspace=mock_workspace, step_id="step-1", repo_root=tmp_path, baseline_state=None
     )
 
     violations = scanner.scan(current_state=state)

--- a/tests/test_security_path_traversal.py
+++ b/tests/test_security_path_traversal.py
@@ -187,6 +187,7 @@ def test_run_state_manager_path_validation(tmp_path):
 
     asyncio.run(run_tests())
 
+
 def test_run_tailer_path_validation(tmp_path):
     """Test that RunTailer validates run_id against path traversal."""
     from swarm.runtime.db import StatsDB


### PR DESCRIPTION
⚡ Bolt: Replace rglob with os.scandir for performance

What: Replaced `pathlib.Path.rglob("*")` with an iterative `os.scandir` implementation in the `get_dir_size` function of `swarm/tools/runs_gc.py`.
Why: `pathlib.Path.rglob` is significantly slower because it creates new Path objects for every matched file/directory and requires a separate `stat()` call. `os.scandir` yields lightweight DirEntry objects and caches the file type and stat information, preventing redundant system calls.
Impact: Directory size calculation during garbage collection operations (which iterates over all run directories and their contents) will be measurably faster and use less memory, reducing GC execution time.
Measurement: Verified via manual testing; execution time on identical run directories will be reduced. Run `uv run swarm/tools/runs_gc.py list` to verify execution correctness.

---
*PR created automatically by Jules for task [17875894843557938290](https://jules.google.com/task/17875894843557938290) started by @EffortlessSteven*