### PR TITLE
⚡ Bolt: [performance improvement] Optimize directory size calculation

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -73,16 +74,25 @@ class RunInfo:
 
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
+    # Performance optimization: using os.scandir instead of Path.rglob reduces object creation overhead and stat calls
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+
+    def _scan(p: str) -> None:
+        nonlocal total
+        try:
+            with os.scandir(p) as it:
+                for entry in it:
+                    if entry.is_file():
+                        try:
+                            total += entry.stat().st_size
+                        except OSError:
+                            pass
+                    elif entry.is_dir(follow_symlinks=False):
+                        _scan(entry.path)
+        except OSError:
+            pass
+
+    _scan(str(path))
     return total
 
 


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Optimize directory size calculation

💡 What: Replaced `pathlib.Path.rglob("*")` with `os.scandir()` in `get_dir_size` of `swarm/tools/runs_gc.py`.

🎯 Why: `rglob` instantiates a new `Path` object and executes stat calls for every traversed directory entry, generating massive overhead on deep directory structures. Using `os.scandir` allows us to iterate through string paths directly.

📊 Impact: Significantly accelerates garbage collection directory size calculations, lowers memory footprint by eliminating object creation churn, and limits duplicate `stat()` operations.

🔬 Measurement: Run `uv run swarm/tools/runs_gc.py list` on directories with numerous nested files.

---
*PR created automatically by Jules for task [6424054521028190919](https://jules.google.com/task/6424054521028190919) started by @EffortlessSteven*