### PR TITLE
⚡ Bolt: [performance improvement] Replace pathlib rglob with os.scandir in runs_gc

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -73,16 +74,23 @@ class RunInfo:
 
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
+    # ⚡ Bolt: Replaced rglob with os.scandir for faster directory traversal
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+    stack = [str(path)]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    if entry.is_dir(follow_symlinks=False):
+                        stack.append(entry.path)
+                    elif entry.is_file():
+                        try:
+                            total += entry.stat().st_size
+                        except OSError:
+                            pass
+        except OSError:
+            pass
     return total
 
 


### PR DESCRIPTION
💡 What: Replaced the `pathlib.Path.rglob("*")` call in `swarm/tools/runs_gc.py`'s `get_dir_size` function with an iterative implementation using `os.scandir`. Added an in-code comment explaining the performance optimization.
🎯 Why: `pathlib.Path.rglob` is significantly slower because it instantiates `Path` objects for every single file and directory in the tree and requires separate `.stat()` calls. `os.scandir` is much faster as it avoids object creation overhead and leverages the OS directory iterator directly, often caching file attributes.
📊 Impact: Expected to reduce execution time of the garbage collection tool significantly when processing large directories with thousands of files, potentially operating 2x-5x faster depending on the OS and filesystem.
🔬 Measurement: Verified the script executes without errors via `uv run swarm/tools/runs_gc.py list`. The performance improvement can be measured by comparing the execution time of `runs_gc.py list` before and after this change on a directory with a large number of runs.

---
*PR created automatically by Jules for task [2756150187808073094](https://jules.google.com/task/2756150187808073094) started by @EffortlessSteven*