### PR TITLE
⚡ Bolt: Optimize directory size calculation

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,15 +75,23 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+    # Performance optimization: Use os.scandir with a stack instead of pathlib.rglob
+    # This avoids excessive stat() calls and object creation, making it much faster
+    dirs_to_visit = [str(path)]
+    while dirs_to_visit:
+        current_dir = dirs_to_visit.pop()
+        try:
+            with os.scandir(current_dir) as it:
+                for entry in it:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            dirs_to_visit.append(entry.path)
+                        elif entry.is_file():
+                            total += entry.stat().st_size
+                    except OSError:
+                        pass
+        except OSError:
+            pass
     return total
 
 


### PR DESCRIPTION
**What:**
Replaced `pathlib.Path.rglob` with an `os.scandir` stack-based traversal in the `get_dir_size` function in `swarm/tools/runs_gc.py`.

**Why:**
`pathlib.Path.rglob` creates heavy `Path` objects and performs excessive `stat()` calls, making it slow for deep directory trees like garbage collection routines.

**Impact:**
Significantly speeds up the discovery and execution times of `uv run swarm/tools/runs_gc.py` across large subdirectories by skipping unnecessary Python object initialization and batching file traversal through `os.DirEntry`.

**Measurement:**
Can be verified by running `uv run swarm/tools/runs_gc.py list` before and after to compare total script execution latency over a run directory containing 1000+ files.

---
*PR created automatically by Jules for task [5843677498664167593](https://jules.google.com/task/5843677498664167593) started by @EffortlessSteven*