### PR TITLE
⚡ Bolt: Optimize get_dir_size with os.scandir

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -73,16 +74,26 @@ class RunInfo:
 
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
+    # Optimization: Use os.scandir recursively to reduce object creation overhead
+    # compared to pathlib.Path.rglob()
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+
+    def _scan(dir_path: str) -> None:
+        nonlocal total
+        try:
+            with os.scandir(dir_path) as it:
+                for entry in it:
+                    try:
+                        if entry.is_file():
+                            total += entry.stat().st_size
+                        elif entry.is_dir(follow_symlinks=False):
+                            _scan(entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+
+    _scan(str(path))
     return total
 
 


### PR DESCRIPTION
💡 What: Replaced `pathlib.Path.rglob("*")` with a custom recursive function using `os.scandir()`.
🎯 Why: `pathlib.Path.rglob` creates Path objects for every file, creating significant overhead when calculating directory sizes.
📊 Impact: Considerably faster execution for `runs_gc.py` when managing directories with thousands of files by eliminating object creation overhead.
🔬 Measurement: Run `uv run swarm/tools/runs_gc.py list` before and after to measure execution time on a populated runs directory.

---
*PR created automatically by Jules for task [13639217476578190444](https://jules.google.com/task/13639217476578190444) started by @EffortlessSteven*