### PR TITLE
🎨 Palette: [Add ARIA label to selftest copy button]

### DIFF
--- a/swarm/tools/flow_studio_ui/js/selftest_ui.js
+++ b/swarm/tools/flow_studio_ui/js/selftest_ui.js
@@ -234,7 +234,7 @@ export function renderSelftestStepModal(step) {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy" aria-label="Copy command">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/src/selftest_ui.ts
+++ b/swarm/tools/flow_studio_ui/src/selftest_ui.ts
@@ -257,7 +257,7 @@ export function renderSelftestStepModal(step: SelftestStep): void {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy" aria-label="Copy command">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>


### PR DESCRIPTION
What: Added `aria-label="Copy command"` to the icon-only copy button within the selftest commands block in `selftest_ui.ts`.
Why: The button only contains a clipboard emoji icon without visible text, making its purpose unclear to screen reader users.
Before/After: 
  - Before: `<button class="selftest-command-copy-btn" title="Copy">📋</button>`
  - After: `<button class="selftest-command-copy-btn" title="Copy" aria-label="Copy command">📋</button>`
Accessibility: Improved compliance with WCAG criteria by providing an accessible name for an icon-only interactive element, enabling assistive technologies to properly announce the button's action.

---
*PR created automatically by Jules for task [15409915685187059594](https://jules.google.com/task/15409915685187059594) started by @EffortlessSteven*