### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in event streaming endpoint

### DIFF
--- a/swarm/api/routes/events.py
+++ b/swarm/api/routes/events.py
@@ -199,7 +199,17 @@ async def generate_run_events(
     Yields:
         SSE-formatted event strings.
     """
-    run_dir = runs_root / run_id
+    # 🛡️ Sentinel: Validate run_id to prevent path traversal vulnerabilities
+    run_dir = (runs_root / run_id).resolve()
+    try:
+        run_dir.relative_to(runs_root.resolve())
+    except ValueError:
+        yield format_sse_event(
+            EventType.ERROR,
+            {"error": "invalid_run_id", "message": "Invalid run ID format"},
+        )
+        return
+
     events_file = run_dir / "events.jsonl"
     state_file = run_dir / "run_state.json"
 
@@ -367,8 +377,20 @@ async def stream_run_events(run_id: str, request: Request):
     except Exception as e:
         logger.warning("DB health check failed on SSE connect: %s", e)
 
+    # 🛡️ Sentinel: Validate run_id to prevent path traversal vulnerabilities
+    run_dir = (runs_root / run_id).resolve()
+    try:
+        run_dir.relative_to(runs_root.resolve())
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_run_id",
+                "message": "Invalid run ID format",
+            },
+        )
+
     # Verify run exists
-    run_dir = runs_root / run_id
     if not run_dir.exists():
         raise HTTPException(
             status_code=404,


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix path traversal in event streaming endpoint

🚨 Severity: HIGH
💡 Vulnerability: The `generate_run_events` and `stream_run_events` endpoints in `swarm/api/routes/events.py` appended user-supplied `run_id` directly to `runs_root` via `pathlib` without sanitization.
🎯 Impact: An attacker could perform a directory traversal attack (e.g. `../../../../etc/passwd`) to escape the `runs_root` and potentially read arbitrary sensitive files on the server running the API.
🔧 Fix: Validated the generated path by calling `.resolve()` and using `.relative_to(runs_root.resolve())`. If the path escapes the root directory, a `ValueError` is caught, and an error response is returned instead of proceeding.
✅ Verification: Ran unit tests for related FastAPI components using `uv run pytest tests/test_flow_studio_fastapi_comprehensive.py -k TestRunEndpoints` and `uv run pytest tests/test_flow_studio_fastapi_smoke.py`, which passed correctly.

---
*PR created automatically by Jules for task [12359122937729599527](https://jules.google.com/task/12359122937729599527) started by @EffortlessSteven*