### PR TITLE
🎨 Palette: Remove redundant ARIA labels from run control buttons

### DIFF
--- a/swarm/tools/flow_studio_ui/fragments/30-sidebar.html
+++ b/swarm/tools/flow_studio_ui/fragments/30-sidebar.html
@@ -6,19 +6,19 @@
     <div class="run-control-panel" data-uiid="flow_studio.sidebar.run_control">
       <label class="muted" style="font-size: 10px; display: block; margin-bottom: 6px;">RUN CONTROL</label>
       <div class="run-control-buttons" data-uiid="flow_studio.sidebar.run_control.buttons">
-        <button id="run-control-play" class="run-control-btn run-control-btn--play" title="Start run" aria-label="Start run" data-uiid="flow_studio.sidebar.run_control.play">
+        <button id="run-control-play" class="run-control-btn run-control-btn--play" title="Start run" data-uiid="flow_studio.sidebar.run_control.play">
           <span class="run-control-icon" aria-hidden="true">&#9654;</span>
           <span class="run-control-label">Start</span>
         </button>
-        <button id="run-control-pause" class="run-control-btn run-control-btn--pause" title="Pause run" aria-label="Pause run" data-uiid="flow_studio.sidebar.run_control.pause" disabled>
+        <button id="run-control-pause" class="run-control-btn run-control-btn--pause" title="Pause run" data-uiid="flow_studio.sidebar.run_control.pause" disabled>
           <span class="run-control-icon" aria-hidden="true">&#10074;&#10074;</span>
           <span class="run-control-label">Pause</span>
         </button>
-        <button id="run-control-resume" class="run-control-btn run-control-btn--resume" title="Resume run" aria-label="Resume run" data-uiid="flow_studio.sidebar.run_control.resume" disabled style="display: none;">
+        <button id="run-control-resume" class="run-control-btn run-control-btn--resume" title="Resume run" data-uiid="flow_studio.sidebar.run_control.resume" disabled style="display: none;">
           <span class="run-control-icon" aria-hidden="true">&#9654;</span>
           <span class="run-control-label">Resume</span>
         </button>
-        <button id="run-control-cancel" class="run-control-btn run-control-btn--stop" title="Stop run" aria-label="Stop run" data-uiid="flow_studio.sidebar.run_control.stop" disabled>
+        <button id="run-control-cancel" class="run-control-btn run-control-btn--stop" title="Stop run" data-uiid="flow_studio.sidebar.run_control.stop" disabled>
           <span class="run-control-icon" aria-hidden="true">&#9632;</span>
           <span class="run-control-label">Stop</span>
         </button>

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -76,19 +76,19 @@
     <div class="run-control-panel" data-uiid="flow_studio.sidebar.run_control">
       <label class="muted" style="font-size: 10px; display: block; margin-bottom: 6px;">RUN CONTROL</label>
       <div class="run-control-buttons" data-uiid="flow_studio.sidebar.run_control.buttons">
-        <button id="run-control-play" class="run-control-btn run-control-btn--play" title="Start run" data-uiid="flow_studio.sidebar.run_control.play">
+        <button id="run-control-play" class="run-control-btn run-control-btn--play" title="Start run" aria-label="Start run" data-uiid="flow_studio.sidebar.run_control.play">
           <span class="run-control-icon" aria-hidden="true">&#9654;</span>
           <span class="run-control-label">Start</span>
         </button>
-        <button id="run-control-pause" class="run-control-btn run-control-btn--pause" title="Pause run" data-uiid="flow_studio.sidebar.run_control.pause" disabled>
+        <button id="run-control-pause" class="run-control-btn run-control-btn--pause" title="Pause run" aria-label="Pause run" data-uiid="flow_studio.sidebar.run_control.pause" disabled>
           <span class="run-control-icon" aria-hidden="true">&#10074;&#10074;</span>
           <span class="run-control-label">Pause</span>
         </button>
-        <button id="run-control-resume" class="run-control-btn run-control-btn--resume" title="Resume run" data-uiid="flow_studio.sidebar.run_control.resume" disabled style="display: none;">
+        <button id="run-control-resume" class="run-control-btn run-control-btn--resume" title="Resume run" aria-label="Resume run" data-uiid="flow_studio.sidebar.run_control.resume" disabled style="display: none;">
           <span class="run-control-icon" aria-hidden="true">&#9654;</span>
           <span class="run-control-label">Resume</span>
         </button>
-        <button id="run-control-cancel" class="run-control-btn run-control-btn--stop" title="Stop run" data-uiid="flow_studio.sidebar.run_control.stop" disabled>
+        <button id="run-control-cancel" class="run-control-btn run-control-btn--stop" title="Stop run" aria-label="Stop run" data-uiid="flow_studio.sidebar.run_control.stop" disabled>
           <span class="run-control-icon" aria-hidden="true">&#9632;</span>
           <span class="run-control-label">Stop</span>
         </button>
@@ -4793,16 +4793,9 @@ export function renderAgentUsage(container, usage, callbacks = {}) {
     list.className = "fs-text-body";
     list.style.lineHeight = "1.8";
     usage.forEach(u => {
-        const item = document.createElement("button");
+        const item = document.createElement("div");
         item.style.cursor = "pointer";
         item.style.padding = "2px 0";
-        item.style.background = "none";
-        item.style.border = "none";
-        item.style.textAlign = "left";
-        item.style.width = "100%";
-        item.style.fontFamily = "inherit";
-        item.style.fontSize = "inherit";
-        item.style.color = "inherit";
         item.innerHTML = renderAgentUsageItem(u.flow_title, u.step_title);
         item.title = `Click to navigate to ${u.flow}:${u.step}`;
         item.addEventListener("click", async () => {
@@ -4826,8 +4819,6 @@ export function renderAgentUsage(container, usage, callbacks = {}) {
         });
         item.addEventListener("mouseenter", () => { item.style.background = "#f3f4f6"; });
         item.addEventListener("mouseleave", () => { item.style.background = "transparent"; });
-        item.addEventListener("focus", () => { item.style.background = "#f3f4f6"; });
-        item.addEventListener("blur", () => { item.style.background = "transparent"; });
         list.appendChild(item);
     });
     container.appendChild(list);
@@ -5255,16 +5246,10 @@ export async function showStepDetails(data, callbacks = {}) {
         }
         else {
             stepAgents.forEach(agentKey => {
-                const agentLink = document.createElement("button");
+                const agentLink = document.createElement("div");
                 agentLink.style.cursor = "pointer";
                 agentLink.style.padding = "2px 0";
                 agentLink.style.color = "#3b82f6";
-                agentLink.style.background = "none";
-                agentLink.style.border = "none";
-                agentLink.style.textAlign = "left";
-                agentLink.style.width = "100%";
-                agentLink.style.fontFamily = "inherit";
-                agentLink.style.fontSize = "inherit";
                 agentLink.innerHTML = `<span class="mono">${escapeHtml(agentKey)}</span>`;
                 agentLink.title = `Click to view agent: ${agentKey}`;
                 agentLink.addEventListener("click", async () => {
@@ -5277,14 +5262,6 @@ export async function showStepDetails(data, callbacks = {}) {
                     agentLink.style.textDecoration = "underline";
                 });
                 agentLink.addEventListener("mouseleave", () => {
-                    agentLink.style.background = "transparent";
-                    agentLink.style.textDecoration = "none";
-                });
-                agentLink.addEventListener("focus", () => {
-                    agentLink.style.background = "#f3f4f6";
-                    agentLink.style.textDecoration = "underline";
-                });
-                agentLink.addEventListener("blur", () => {
                     agentLink.style.background = "transparent";
                     agentLink.style.textDecoration = "none";
                 });
@@ -10156,10 +10133,7 @@ export function renderNoRuns() {
       <div class="fs-empty-icon" aria-hidden="true">\u{1F4C2}</div>
       <p class="fs-empty-title">No runs yet</p>
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
-      <div class="fs-copy-command">
-        <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
-      </div>
+      <code class="mono fs-empty-command">make demo-run</code>
     </div>
   `;
 }

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -76,19 +76,19 @@
     <div class="run-control-panel" data-uiid="flow_studio.sidebar.run_control">
       <label class="muted" style="font-size: 10px; display: block; margin-bottom: 6px;">RUN CONTROL</label>
       <div class="run-control-buttons" data-uiid="flow_studio.sidebar.run_control.buttons">
-        <button id="run-control-play" class="run-control-btn run-control-btn--play" title="Start run" aria-label="Start run" data-uiid="flow_studio.sidebar.run_control.play">
+        <button id="run-control-play" class="run-control-btn run-control-btn--play" title="Start run" data-uiid="flow_studio.sidebar.run_control.play">
           <span class="run-control-icon" aria-hidden="true">&#9654;</span>
           <span class="run-control-label">Start</span>
         </button>
-        <button id="run-control-pause" class="run-control-btn run-control-btn--pause" title="Pause run" aria-label="Pause run" data-uiid="flow_studio.sidebar.run_control.pause" disabled>
+        <button id="run-control-pause" class="run-control-btn run-control-btn--pause" title="Pause run" data-uiid="flow_studio.sidebar.run_control.pause" disabled>
           <span class="run-control-icon" aria-hidden="true">&#10074;&#10074;</span>
           <span class="run-control-label">Pause</span>
         </button>
-        <button id="run-control-resume" class="run-control-btn run-control-btn--resume" title="Resume run" aria-label="Resume run" data-uiid="flow_studio.sidebar.run_control.resume" disabled style="display: none;">
+        <button id="run-control-resume" class="run-control-btn run-control-btn--resume" title="Resume run" data-uiid="flow_studio.sidebar.run_control.resume" disabled style="display: none;">
           <span class="run-control-icon" aria-hidden="true">&#9654;</span>
           <span class="run-control-label">Resume</span>
         </button>
-        <button id="run-control-cancel" class="run-control-btn run-control-btn--stop" title="Stop run" aria-label="Stop run" data-uiid="flow_studio.sidebar.run_control.stop" disabled>
+        <button id="run-control-cancel" class="run-control-btn run-control-btn--stop" title="Stop run" data-uiid="flow_studio.sidebar.run_control.stop" disabled>
           <span class="run-control-icon" aria-hidden="true">&#9632;</span>
           <span class="run-control-label">Stop</span>
         </button>
@@ -4793,9 +4793,16 @@ export function renderAgentUsage(container, usage, callbacks = {}) {
     list.className = "fs-text-body";
     list.style.lineHeight = "1.8";
     usage.forEach(u => {
-        const item = document.createElement("div");
+        const item = document.createElement("button");
         item.style.cursor = "pointer";
         item.style.padding = "2px 0";
+        item.style.background = "none";
+        item.style.border = "none";
+        item.style.textAlign = "left";
+        item.style.width = "100%";
+        item.style.fontFamily = "inherit";
+        item.style.fontSize = "inherit";
+        item.style.color = "inherit";
         item.innerHTML = renderAgentUsageItem(u.flow_title, u.step_title);
         item.title = `Click to navigate to ${u.flow}:${u.step}`;
         item.addEventListener("click", async () => {
@@ -4819,6 +4826,8 @@ export function renderAgentUsage(container, usage, callbacks = {}) {
         });
         item.addEventListener("mouseenter", () => { item.style.background = "#f3f4f6"; });
         item.addEventListener("mouseleave", () => { item.style.background = "transparent"; });
+        item.addEventListener("focus", () => { item.style.background = "#f3f4f6"; });
+        item.addEventListener("blur", () => { item.style.background = "transparent"; });
         list.appendChild(item);
     });
     container.appendChild(list);
@@ -5246,10 +5255,16 @@ export async function showStepDetails(data, callbacks = {}) {
         }
         else {
             stepAgents.forEach(agentKey => {
-                const agentLink = document.createElement("div");
+                const agentLink = document.createElement("button");
                 agentLink.style.cursor = "pointer";
                 agentLink.style.padding = "2px 0";
                 agentLink.style.color = "#3b82f6";
+                agentLink.style.background = "none";
+                agentLink.style.border = "none";
+                agentLink.style.textAlign = "left";
+                agentLink.style.width = "100%";
+                agentLink.style.fontFamily = "inherit";
+                agentLink.style.fontSize = "inherit";
                 agentLink.innerHTML = `<span class="mono">${escapeHtml(agentKey)}</span>`;
                 agentLink.title = `Click to view agent: ${agentKey}`;
                 agentLink.addEventListener("click", async () => {
@@ -5262,6 +5277,14 @@ export async function showStepDetails(data, callbacks = {}) {
                     agentLink.style.textDecoration = "underline";
                 });
                 agentLink.addEventListener("mouseleave", () => {
+                    agentLink.style.background = "transparent";
+                    agentLink.style.textDecoration = "none";
+                });
+                agentLink.addEventListener("focus", () => {
+                    agentLink.style.background = "#f3f4f6";
+                    agentLink.style.textDecoration = "underline";
+                });
+                agentLink.addEventListener("blur", () => {
                     agentLink.style.background = "transparent";
                     agentLink.style.textDecoration = "none";
                 });
@@ -10133,7 +10156,10 @@ export function renderNoRuns() {
       <div class="fs-empty-icon" aria-hidden="true">\u{1F4C2}</div>
       <p class="fs-empty-title">No runs yet</p>
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
-      <code class="mono fs-empty-command">make demo-run</code>
+      <div class="fs-copy-command">
+        <code class="mono fs-empty-command">make demo-run</code>
+        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+      </div>
     </div>
   `;
 }


### PR DESCRIPTION
What: Removed redundant `aria-label` attributes from the run control buttons in the sidebar (`30-sidebar.html`).
Why: The buttons already have visible text inside a `<span class="run-control-label">` child element, as well as `title` attributes. Adding `aria-label` when visible text is present is redundant and violates WCAG 2.5.3 (Label in Name), as it can interfere with voice recognition software.
Before/After: 
  - Before: `<button ... aria-label="Start run">... <span class="run-control-label">Start</span></button>`
  - After: `<button ...>... <span class="run-control-label">Start</span></button>`
Accessibility: Improves compliance with WCAG 2.5.3 and prevents screen readers from redundantly announcing the button label.

---
*PR created automatically by Jules for task [7154524990985269295](https://jules.google.com/task/7154524990985269295) started by @EffortlessSteven*