### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix SQL injection in DB stats

### DIFF
--- a/swarm/api/routes/db.py
+++ b/swarm/api/routes/db.py
@@ -240,8 +240,17 @@ async def get_db_stats():
 
         conn = stats_db.connection
 
+        # Valid tables in the schema
+        valid_tables = {
+            "schema_version", "_projection_meta", "runs", "steps",
+            "tool_calls", "file_changes", "events", "ingestion_state",
+            "facts", "routing_decisions"
+        }
+
         # Query counts from each table
         def safe_count(table: str) -> int:
+            if table not in valid_tables:
+                return 0
             try:
                 result = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
                 return result[0] if result else 0


### PR DESCRIPTION
## 🛡️ Sentinel Security Fix

**Severity:** MEDIUM
**Vulnerability:** SQL Injection (SQLi)
**Impact:** 
The `get_db_stats` endpoint contains an internal `safe_count` function that dynamically interpolates the `table` argument into a SQL query using an f-string: `f"SELECT COUNT(*) FROM {table}"`. Because SQL drivers do not support parameterizing table identifiers, string interpolation is the only way to make it dynamic. However, without strict validation, this creates a potential SQL injection vulnerability if untrusted input ever reaches this function. Even as an internal function, this is flagged as a static analysis warning and poor practice.

**Fix:** 
Introduced a hardcoded allowlist (`valid_tables`) containing exactly the ten tables defined in the schema. The `safe_count` function now strictly verifies if the `table` argument exists in this allowlist before executing the query. If it's invalid, it fails safely by returning 0, perfectly mitigating the risk without crashing.

**Verification:**
- Validated via `uv run ruff check swarm/api/routes/db.py`.
- Ran relevant DB and API tests via `uv run pytest tests/test_db_projection.py tests/test_resilient_db.py` which all pass.

---
*PR created automatically by Jules for task [7895099595178330852](https://jules.google.com/task/7895099595178330852) started by @EffortlessSteven*