### PR TITLE
🎨 Palette: Add aria-label to expand button

### DIFF
--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-label="Toggle expand">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-label="Toggle expand">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>


### PR DESCRIPTION
🎨 Palette: Add aria-label to expand button

What: Added an `aria-label="Toggle expand"` attribute to the icon-only toggle-expand button in the Boundary Review panel (`swarm/tools/flow_studio_ui/src/boundary_review.ts`).
Why: Screen readers could not determine the accessible name of the button since it only contained the visual icons "▼" or "▶".
Before/After: Before, the button was `<button class="toggle-expand" title="Toggle expand">`. After, it is `<button class="toggle-expand" title="Toggle expand" aria-label="Toggle expand">`.
Accessibility: Improves screen reader navigation and correctly identifies the action to visually impaired users, aligning with WCAG standards for icon-only buttons.

---
*PR created automatically by Jules for task [5057877974882885818](https://jules.google.com/task/5057877974882885818) started by @EffortlessSteven*