### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,15 +75,26 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+
+    # PERFORMANCE OPTIMIZATION:
+    # Use iterative os.scandir instead of Path.rglob("*")
+    # This prevents the overhead of creating Path objects for every file
+    # and reduces memory usage for very large run directories.
+    stack = [str(path)]
+    while stack:
+        current = stack.pop()
+        try:
+            with os.scandir(current) as it:
+                for entry in it:
+                    try:
+                        if entry.is_dir(follow_symlinks=False):
+                            stack.append(entry.path)
+                        elif entry.is_file(follow_symlinks=False):
+                            total += entry.stat(follow_symlinks=False).st_size
+                    except OSError:
+                        pass
+        except OSError:
+            pass
     return total
 
 


### PR DESCRIPTION
💡 What: Replaced `Path.rglob("*")` with an iterative `os.scandir` implementation in `get_dir_size` within `swarm/tools/runs_gc.py`.
🎯 Why: `Path.rglob("*")` creates full `Path` objects for every file and performs recursive resolution which is slow and memory-intensive for large directories. `os.scandir` uses a stack, yields lightweight `DirEntry` objects, and avoids excessive system stat calls.
📊 Impact: Considerably faster directory tree traversals for run directory size calculations and a significant reduction in memory usage.
🔬 Measurement: Verified with a local benchmark script measuring `rglob` vs `scandir` execution times on a directory tree, confirming correct behavior and zero syntactical issues via tests.

---
*PR created automatically by Jules for task [18114311893690845207](https://jules.google.com/task/18114311893690845207) started by @EffortlessSteven*