### PR TITLE
⚡ Bolt: Optimize get_dir_size with os.scandir

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,15 +75,25 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+    # Optimization: Use os.scandir with an iterative stack instead of Path.rglob.
+    # This avoids the overhead of instantiating Path objects for every file,
+    # prevents Python recursion depth limits on deep directories, and safely
+    # handles symlinks and OS permission errors file-by-file.
+    stack = [str(path)]
+    while stack:
+        current_dir = stack.pop()
+        try:
+            with os.scandir(current_dir) as it:
+                for entry in it:
+                    try:
+                        if entry.is_file(follow_symlinks=False):
+                            total += entry.stat(follow_symlinks=False).st_size
+                        elif entry.is_dir(follow_symlinks=False):
+                            stack.append(entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
     return total
 
 


### PR DESCRIPTION
⚡ Bolt: Optimize get_dir_size with os.scandir

💡 What:
Replaced `Path.rglob("*")` with an iterative `os.scandir` implementation using a stack in `get_dir_size` in `swarm/tools/runs_gc.py`.

🎯 Why:
`Path.rglob` is slow for deeply nested or large directories because it creates `Path` objects for every file. Using `os.scandir` with a stack bypasses `Path` object creation and recursion limits, significantly speeding up directory size calculations used during garbage collection.

📊 Impact:
Significantly reduces file stat overhead and time taken to calculate directory sizes, minimizing CPU usage and making the GC tool run faster. Prevents RecursionError for deeply nested directories.

🔬 Measurement:
Run `uv run python swarm/tools/runs_gc.py list` and observe the reduced execution time compared to the previous version.

---
*PR created automatically by Jules for task [2492112989542802544](https://jules.google.com/task/2492112989542802544) started by @EffortlessSteven*