### PR TITLE
🛡️ Sentinel: [LOW] Fix potential SQL injection in safe_count

### DIFF
--- a/swarm/api/routes/db.py
+++ b/swarm/api/routes/db.py
@@ -242,6 +242,12 @@ async def get_db_stats():
 
         # Query counts from each table
         def safe_count(table: str) -> int:
+            # Explicit allowlist to prevent SQL injection via f-string
+            allowed_tables = {"runs", "steps", "tool_calls", "file_changes", "events", "facts"}
+            if table not in allowed_tables:
+                logger.warning(f"Attempted to query unauthorized table: {table}")
+                return 0
+
             try:
                 result = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
                 return result[0] if result else 0


### PR DESCRIPTION
🚨 Severity: LOW
💡 Vulnerability: The `safe_count` function in `swarm/api/routes/db.py` used string interpolation (`f"SELECT COUNT(*) FROM {table}"`) for the table name, presenting a potential SQL injection vulnerability if external input reached it.
🎯 Impact: While currently only called internally with safe literal strings, this pattern violates defense-in-depth principles and triggered SAST warnings.
🔧 Fix: Implemented an explicit allowlist of authorized table names. If an unrecognized table is passed, it logs a warning and returns 0 instead of executing the query.
✅ Verification: Tested locally via `uv run pytest tests/test_db_projection.py tests/test_resilient_db.py` which all passed. Verified visually that only valid internal table queries succeed.

---
*PR created automatically by Jules for task [6678886924565415062](https://jules.google.com/task/6678886924565415062) started by @EffortlessSteven*