### PR TITLE
🎨 Palette: [UX improvement] Add missing ARIA label to copy button

### DIFF
--- a/swarm/tools/flow_studio_ui/js/ui_fragments.js
+++ b/swarm/tools/flow_studio_ui/js/ui_fragments.js
@@ -21,7 +21,7 @@ export function renderNoRuns() {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy demo command to clipboard" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;

--- a/swarm/tools/flow_studio_ui/src/ui_fragments.ts
+++ b/swarm/tools/flow_studio_ui/src/ui_fragments.ts
@@ -24,7 +24,7 @@ export function renderNoRuns(): string {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy demo command to clipboard" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add missing ARIA label to copy button

💡 What: Added an `aria-label` attribute to the icon-only "Copy" button in the empty state view of Flow Studio's sidebar.
🎯 Why: Icon-only buttons without an accessible name are invisible to screen readers, creating a poor experience for users relying on assistive technologies.
📸 Before/After:
Before: `<button class="fs-icon-button copy-button" title="Copy command" ...>📋</button>`
After: `<button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy demo command to clipboard" ...>📋</button>`
♿ Accessibility: Improves compliance with WCAG SC 2.5.3 (Label in Name) by providing a clear, programmatic accessible name for the clipboard copy action.

---
*PR created automatically by Jules for task [10357012841780736127](https://jules.google.com/task/10357012841780736127) started by @EffortlessSteven*