### PR TITLE
🎨 Palette: [UX improvement] Add aria-label to toggle-expand button

### DIFF
--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-label="${isExpanded ? 'Collapse boundary review' : 'Expand boundary review'}" aria-expanded="${isExpanded ? 'true' : 'false'}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -309,6 +309,8 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-label", isExpanded ? "Collapse boundary review" : "Expand boundary review");
+            target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-label="${isExpanded ? 'Collapse boundary review' : 'Expand boundary review'}" aria-expanded="${isExpanded ? 'true' : 'false'}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -345,6 +345,8 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-label", isExpanded ? "Collapse boundary review" : "Expand boundary review");
+      target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
     }
   });
 }


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add aria-label to toggle-expand button

💡 What: Added dynamic `aria-label` and `aria-expanded` attributes to the boundary review panel's toggle-expand icon button.
🎯 Why: The button previously relied solely on text symbols ("▼" / "▶") to convey meaning, making it inaccessible to screen reader users who could not determine its purpose or its current expanded/collapsed state.
📸 Before/After: Visuals remain identical, but DOM now includes semantic attributes: `<button class="toggle-expand" aria-label="Expand boundary review" aria-expanded="false">▶</button>`
♿ Accessibility: Ensures the control meets WCAG SC 4.1.2 (Name, Role, Value) by giving the icon-only toggle button an explicit accessible name and state.

---
*PR created automatically by Jules for task [14988601748086258626](https://jules.google.com/task/14988601748086258626) started by @EffortlessSteven*