### PR TITLE
⚡ Bolt: Optimize get_dir_size with iterative os.scandir

### DIFF
--- a/swarm/tools/runs_gc.py
+++ b/swarm/tools/runs_gc.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 from dataclasses import dataclass
@@ -74,15 +75,24 @@ class RunInfo:
 def get_dir_size(path: Path) -> int:
     """Get total size of a directory in bytes."""
     total = 0
-    try:
-        for entry in path.rglob("*"):
-            if entry.is_file():
-                try:
-                    total += entry.stat().st_size
-                except OSError:
-                    pass
-    except OSError:
-        pass
+    # Optimization: Use iterative os.scandir instead of Path.rglob("*")
+    # os.scandir is significantly faster as it caches file stats, avoiding
+    # redundant system calls and Path object instantiations.
+    stack = [str(path)]
+    while stack:
+        current_dir = stack.pop()
+        try:
+            with os.scandir(current_dir) as it:
+                for entry in it:
+                    try:
+                        if entry.is_file(follow_symlinks=False):
+                            total += entry.stat(follow_symlinks=False).st_size
+                        elif entry.is_dir(follow_symlinks=False):
+                            stack.append(entry.path)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
     return total
 
 


### PR DESCRIPTION
⚡ Bolt: Optimize get_dir_size with iterative os.scandir

What: Replaced the recursive `Path.rglob("*")` implementation in `get_dir_size` (`swarm/tools/runs_gc.py`) with a custom iterative stack-based traversal using `os.scandir`.
Why: `Path.rglob("*")` is notoriously slow because it instantiates a `Path` object for every single file and requires separate system calls to retrieve file metadata via `stat()`. `os.scandir` yields directory entries that cache file attributes, completely avoiding these extra system calls and the overhead of `Path` object instantiation.
Impact: Significantly faster directory size calculation, avoiding recursive depth limit issues and improving overall garbage collection performance. It also avoids counting out-of-tree symlinks by setting `follow_symlinks=False`.
Measurement: The change can be verified by running the `uv run swarm/tools/runs_gc.py list` command on a large directory of runs and comparing execution time before and after the optimization.

---
*PR created automatically by Jules for task [17371658460967478805](https://jules.google.com/task/17371658460967478805) started by @EffortlessSteven*