### PR TITLE
🎨 Palette: Add aria-label to boundary review toggle

### DIFF
--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-label="Toggle expand">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-label="Toggle expand">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>


### PR DESCRIPTION
🎨 Palette: Add aria-label to boundary review toggle

**What:** Added an `aria-label="Toggle expand"` attribute to the icon-only toggle button in the Boundary Review UI panel (`boundary_review.ts`).

**Why:** The button previously only had a `title` attribute and visual icons (▼/▶) to convey its purpose. Screen readers and assistive technologies require a proper `aria-label` to announce the action clearly to users.

**Before/After:**
Before: `<button class="toggle-expand" title="Toggle expand">`
After: `<button class="toggle-expand" title="Toggle expand" aria-label="Toggle expand">`

**Accessibility:** Improved screen reader navigation and compliance with WCAG SC 2.5.3 by ensuring an icon-only interactive element has a programmatic accessible name.

---
*PR created automatically by Jules for task [2007987940854095183](https://jules.google.com/task/2007987940854095183) started by @EffortlessSteven*