### PR TITLE
🎨 Palette: Add ARIA attributes to Boundary Review toggle button

### DIFF
--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -12812,7 +12812,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-label="Expand boundary review details" aria-expanded="${isExpanded ? "true" : "false"}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -12885,6 +12885,7 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
         }
     });
 }


### PR DESCRIPTION
🎨 Palette: Add ARIA attributes to Boundary Review toggle button

**What:**
Added `aria-label="Expand boundary review details"` and dynamic `aria-expanded` attributes to the `toggle-expand` button in the Boundary Review panel. The `aria-expanded` state correctly toggles between true and false when clicked.

**Why:**
The toggle-expand button was an icon-only button (showing "▼" or "▶") without any textual description or state communication. This made it inaccessible to screen reader users who would not know what the button does or whether the section is currently expanded or collapsed.

**Before/After:**
Before: `<button class="toggle-expand" title="Toggle expand">▼</button>`
After: `<button class="toggle-expand" title="Toggle expand" aria-label="Expand boundary review details" aria-expanded="true">▼</button>`

**Accessibility:**
- Added `aria-label` to provide an accessible name for the icon-only button.
- Added `aria-expanded` to communicate the current state (expanded/collapsed) to assistive technologies.
- Ensures the state is dynamically updated via JavaScript when the user interacts with the button.

---
*PR created automatically by Jules for task [1178035934545508236](https://jules.google.com/task/1178035934545508236) started by @EffortlessSteven*