### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in DB stats endpoint

### DIFF
--- a/swarm/api/routes/db.py
+++ b/swarm/api/routes/db.py
@@ -242,6 +242,9 @@ async def get_db_stats():
 
         # Query counts from each table
         def safe_count(table: str) -> int:
+            allowed_tables = {'runs', 'steps', 'tool_calls', 'file_changes', 'events', 'facts'}
+            if table not in allowed_tables:
+                return 0
             try:
                 result = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
                 return result[0] if result else 0


### PR DESCRIPTION
Severity: CRITICAL
Vulnerability: SQL injection vulnerability in the database stats endpoint (`get_db_stats`). The `safe_count` function executed queries using an unparameterized f-string (`f"SELECT COUNT(*) FROM {table}"`). If an attacker could control the `table` input, they could execute arbitrary SQL queries against the DuckDB database.
Impact: An attacker could extract sensitive data, manipulate the database, or potentially cause a denial of service by executing malicious SQL queries.
Fix: Implemented a strict allowlist of known tables (`runs`, `steps`, `tool_calls`, `file_changes`, `events`, `facts`) inside the `safe_count` function. The function now immediately returns `0` if the provided table name is not in the allowlist, preventing any arbitrary SQL execution.
Verification: The change was verified using `ruff check` and tests. The fix correctly blocks any unapproved table names from reaching the SQL execution statement.

---
*PR created automatically by Jules for task [15858836301253088186](https://jules.google.com/task/15858836301253088186) started by @EffortlessSteven*