### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection in db.py

### DIFF
--- a/swarm/api/routes/db.py
+++ b/swarm/api/routes/db.py
@@ -242,6 +242,21 @@ async def get_db_stats():
 
         # Query counts from each table
         def safe_count(table: str) -> int:
+            # SECURITY: Enforce allowlist to prevent SQL injection via string formatting
+            allowed_tables = {
+                "runs",
+                "steps",
+                "tool_calls",
+                "file_changes",
+                "events",
+                "facts",
+                "schema_version",
+                "_projection_meta",
+                "ingestion_state",
+                "routing_decisions",
+            }
+            if table not in allowed_tables:
+                return 0
             try:
                 result = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
                 return result[0] if result else 0


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `safe_count` function in `swarm/api/routes/db.py` previously interpolated the `table` variable directly into a SQL query string (`f"SELECT COUNT(*) FROM {table}"`). Because table names cannot be parameterized in DuckDB/SQLite/SQL, an attacker controlling the `table` input could inject arbitrary SQL commands.
🎯 Impact: This could allow a malicious user to exfiltrate database contents, manipulate data, drop tables, or potentially escalate privileges by executing arbitrary SQL statements on the `_duckdb` connection.
🔧 Fix: Added an explicit allowlist of known-good, hardcoded table names (`runs`, `steps`, `tool_calls`, `file_changes`, `events`, `facts`, `schema_version`, `_projection_meta`, `ingestion_state`, `routing_decisions`). If the requested table is not in this set, it securely fails by returning `0` without executing any SQL. Also added a security comment.
✅ Verification: Ran the test suite locally (`pytest tests/test_resilient_db.py` and `pytest tests/test_db_projection.py`) to confirm the allowlist does not break existing functional statistics aggregations or health endpoints.

---
*PR created automatically by Jules for task [17849880978448364211](https://jules.google.com/task/17849880978448364211) started by @EffortlessSteven*