### PR TITLE
🎨 Palette: Add ARIA label to copy button in empty state

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-24 - Missing ARIA label on copy button in empty state
+**Learning:** Icon-only buttons in empty state templates are easy to miss because they're dynamically rendered fragments. In `swarm/tools/flow_studio_ui/src/ui_fragments.ts`, the copy button for `make demo-run` has a title but lacks an `aria-label`.
+**Action:** When auditing icon-only buttons, search beyond static HTML and check template literals in TypeScript files that generate UI fragments.

--- a/swarm/tools/flow_studio_ui/js/ui_fragments.js
+++ b/swarm/tools/flow_studio_ui/js/ui_fragments.js
@@ -21,7 +21,7 @@ export function renderNoRuns() {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;

--- a/swarm/tools/flow_studio_ui/src/ui_fragments.ts
+++ b/swarm/tools/flow_studio_ui/src/ui_fragments.ts
@@ -24,7 +24,7 @@ export function renderNoRuns(): string {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;


### PR DESCRIPTION
💡 What: Added an `aria-label="Copy command"` to the icon-only copy button in the empty state component (`renderNoRuns`).\n🎯 Why: Icon-only buttons without an accessible name are not read correctly by screen readers, creating an accessibility barrier.\n📸 Before/After: Visuals remain unchanged. Screen readers now announce "Copy command" instead of reading the icon unicode character.\n♿ Accessibility: Improves keyboard and screen reader accessibility by providing an explicit accessible name for an icon-only button.

---
*PR created automatically by Jules for task [734483739420404153](https://jules.google.com/task/734483739420404153) started by @EffortlessSteven*