### PR TITLE
🎨 Palette: Add aria-expanded to boundary review toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-04-30 - Add aria-expanded to expandable boundary review button
+**Learning:** Found a missing `aria-expanded` state on the `toggle-expand` button in the boundary review component, making it difficult for screen readers to know if the sections are collapsed or expanded.
+**Action:** Consistently add `aria-expanded` boolean attributes to expand/collapse buttons and ensure the JS event listener updates the property so screen readers have an accurate, sync'd state.

--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? "true" : "false"}" aria-label="Toggle sections">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -309,6 +309,7 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? "true" : "false"}" aria-label="Toggle sections">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -345,6 +345,7 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
     }
   });
 }


### PR DESCRIPTION
💡 What: Added aria-expanded attribute to the expand/collapse button in the BoundaryReview component and wired the JS toggle handler to update it. Also added an aria-label for better description.

🎯 Why: To improve keyboard and screen reader accessibility for collapsible sections in the boundary review panel.

📸 Before/After: N/A (Non-visual change, DOM structure only)

♿ Accessibility: Screen reader users will now be announced the correct open/closed state of the boundary review sections.

---
*PR created automatically by Jules for task [10092396925277231723](https://jules.google.com/task/10092396925277231723) started by @EffortlessSteven*