### PR TITLE
🎨 Palette: Add ARIA state to collapsible rejected candidates

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-11-20 - Accessible Accordion Toggles
+**Learning:** Custom collapsible sections (like candidate rejections in decision cards) frequently miss `aria-expanded` bindings, leaving screen reader users unaware of their state. Additionally, text-based icons (like `▼` or `▶`) create noise if not hidden with `aria-hidden="true"`.
+**Action:** Always bind `aria-expanded` to the expanded state variable, and explicitly hide decorative arrow spans from screen readers.

--- a/swarm/tools/flow_studio_ui/js/components/RoutingDecisionCard.js
+++ b/swarm/tools/flow_studio_ui/js/components/RoutingDecisionCard.js
@@ -288,8 +288,8 @@ export class RoutingDecisionCard {
             .join("");
         return `
       <div class="routing-card__section routing-card__rejected ${expandedClass}">
-        <button class="routing-card__rejected-toggle" data-action="toggle-rejected">
-          <span class="routing-card__rejected-arrow">${arrowIcon}</span>
+        <button class="routing-card__rejected-toggle" data-action="toggle-rejected" aria-expanded="${this.isExpanded ? 'true' : 'false'}">
+          <span class="routing-card__rejected-arrow" aria-hidden="true">${arrowIcon}</span>
           <span>Other Candidates (${candidates.length})</span>
         </button>
         <div class="routing-card__rejected-content">

--- a/swarm/tools/flow_studio_ui/pnpm-lock.yaml
+++ b/swarm/tools/flow_studio_ui/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.3: {}

--- a/swarm/tools/flow_studio_ui/src/components/RoutingDecisionCard.ts
+++ b/swarm/tools/flow_studio_ui/src/components/RoutingDecisionCard.ts
@@ -441,8 +441,8 @@ export class RoutingDecisionCard {
 
     return `
       <div class="routing-card__section routing-card__rejected ${expandedClass}">
-        <button class="routing-card__rejected-toggle" data-action="toggle-rejected">
-          <span class="routing-card__rejected-arrow">${arrowIcon}</span>
+        <button class="routing-card__rejected-toggle" data-action="toggle-rejected" aria-expanded="${this.isExpanded ? 'true' : 'false'}">
+          <span class="routing-card__rejected-arrow" aria-hidden="true">${arrowIcon}</span>
           <span>Other Candidates (${candidates.length})</span>
         </button>
         <div class="routing-card__rejected-content">


### PR DESCRIPTION
🎨 Palette: Add ARIA state to collapsible rejected candidates

💡 What: Added `aria-expanded` and `aria-hidden` attributes to the "Other Candidates" toggle button in the Routing Decision card to improve accessibility.
🎯 Why: Screen reader users could not tell if the "Other Candidates" section was expanded or collapsed, and the decorative arrow character added audio noise.
📸 Before/After: N/A (Non-visual DOM change)
♿ Accessibility: Improved keyboard/screen-reader accessibility for collapsible decision elements.

---
*PR created automatically by Jules for task [8322715390146945160](https://jules.google.com/task/8322715390146945160) started by @EffortlessSteven*