### PR TITLE
🎨 Palette: Add ARIA labels to Boundary Review expand button

### DIFF
--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-label="${isExpanded ? 'Collapse section' : 'Expand section'}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -309,6 +309,8 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+            target.setAttribute("aria-label", isExpanded ? "Collapse section" : "Expand section");
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-label="${isExpanded ? 'Collapse section' : 'Expand section'}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -345,6 +345,8 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
+      target.setAttribute("aria-label", isExpanded ? "Collapse section" : "Expand section");
     }
   });
 }


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to Boundary Review expand button

💡 What: Added `aria-expanded` and dynamic `aria-label` attributes to the toggle-expand button in the Boundary Review panel.

🎯 Why: The button was icon-only (showing '▶' or '▼') and lacked screen reader context about its state and purpose, making it inaccessible for keyboard and screen reader users.

📸 Before/After: Visuals remain unchanged, but screen readers will now announce 'Expand section' or 'Collapse section'.

♿ Accessibility: Improved screen reader navigation by ensuring state changes are properly announced using WAI-ARIA best practices.

---
*PR created automatically by Jules for task [4050856915977079082](https://jules.google.com/task/4050856915977079082) started by @EffortlessSteven*