### PR TITLE
🎨 Palette: [UX improvement] Add accessible states to expand/collapse boundary review panel

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-24 - Dynamic Content Missing Aria-Expanded State
+**Learning:** Found an accessibility issue where dynamic "toggle-expand" buttons controlled the visibility of sections without syncing `aria-expanded` attributes or mapping `aria-controls` for screen reader assistance.
+**Action:** Next time creating a dynamic expand/collapse section, always start by declaring the initial `aria-expanded` and link elements with `aria-controls`. Also, ensure the toggle click handlers continuously update the `aria-expanded` attribute.

--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-controls="boundary-sections-content">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -244,7 +244,7 @@ export function renderBoundaryReviewPanel(data) {
       ${renderSummaryBar(data)}
       ${renderUncertaintyNotes(data.uncertainty_notes)}
 
-      <div class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
+      <div id="boundary-sections-content" class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
         ${renderSection("Assumptions", assumptionCards, assumptionCards.length > 5)}
         ${renderSection("Decisions", decisionCards, decisionCards.length > 5)}
         ${renderSection("Detours", detourCards)}
@@ -309,6 +309,7 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-controls="boundary-sections-content">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -273,7 +273,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       ${renderSummaryBar(data)}
       ${renderUncertaintyNotes(data.uncertainty_notes)}
 
-      <div class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
+      <div id="boundary-sections-content" class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
         ${renderSection("Assumptions", assumptionCards, assumptionCards.length > 5)}
         ${renderSection("Decisions", decisionCards, decisionCards.length > 5)}
         ${renderSection("Detours", detourCards)}
@@ -345,6 +345,7 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
     }
   });
 }


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add accessible states to expand/collapse boundary review panel

💡 What: Added `aria-expanded` and `aria-controls` attributes to the boundary review toggle-expand button, and updated the state logically within the click handler.

🎯 Why: Expanding/collapsing panels without accessible attributes leaves screen readers unaware of the content state and limits navigation. Ensuring the button reflects its state provides accurate auditory context.

📸 Before/After: Before, no `aria-expanded` or `aria-controls` state was set, rendering the button indistinguishable to assistive technologies. After, the state dynamically responds to the user's action.

♿ Accessibility: Improves accessibility for screen reader users by tracking the visible state.

---
*PR created automatically by Jules for task [4142593341071322352](https://jules.google.com/task/4142593341071322352) started by @EffortlessSteven*