### PR TITLE
⚡ Bolt: Replace copy.deepcopy with JSON serialization for RunPlanSpec

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+## 2026-01-24 - Fast Deep Cloning Dataclasses
+**Learning:** Using `copy.deepcopy` on heavily nested dataclasses is a significant performance anti-pattern.
+**Action:** For safe and significant speedups, use JSON dictionary conversion (e.g., `run_plan_spec_from_dict(run_plan_spec_to_dict(obj))`) when a full deep clone is explicitly required.

--- a/swarm/runtime/run_plan_api.py
+++ b/swarm/runtime/run_plan_api.py
@@ -519,9 +519,8 @@ class RunPlanAPI:
             raise ValueError(f"Plan already exists: {new_id}")
 
         # Deep copy the spec
-        import copy
-
-        new_spec = copy.deepcopy(source.spec)
+        # Optimization: using to/from dict conversion is much faster than copy.deepcopy
+        new_spec = run_plan_spec_from_dict(run_plan_spec_to_dict(source.spec))
 
         new_plan = StoredPlan(
             metadata=PlanMetadata(


### PR DESCRIPTION
⚡ Bolt: Replace copy.deepcopy with JSON serialization for RunPlanSpec

💡 What
Replaced `copy.deepcopy(source.spec)` with `run_plan_spec_from_dict(run_plan_spec_to_dict(source.spec))` in `swarm/runtime/run_plan_api.py` when cloning `RunPlanSpec` instances.

🎯 Why
Using `copy.deepcopy` on heavily nested dataclasses is a known Python performance anti-pattern in this codebase. Dictionary/JSON-based serialization is significantly faster for deep cloning.

📊 Impact
Noticeable performance improvement when cloning plans due to bypassing the high overhead of Python's `copy.deepcopy`.

🔬 Measurement
Verify that the test suite still passes, specifically `tests/test_run_plan_api.py`.

---
*PR created automatically by Jules for task [17482182527519988605](https://jules.google.com/task/17482182527519988605) started by @EffortlessSteven*