### PR TITLE
🎨 Palette: Improve accessibility of boundary review toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-04 - Expand/Collapse Accessibility
+**Learning:** Custom expand/collapse buttons often lack `aria-expanded` and `aria-controls` attributes, leaving screen reader users blind to their state and what they control.
+**Action:** Always ensure custom toggles have `aria-expanded` synced with their state and `aria-controls` pointing to the ID of the collapsible content.

--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-controls="boundary-sections-${data.run_id}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -244,7 +244,7 @@ export function renderBoundaryReviewPanel(data) {
       ${renderSummaryBar(data)}
       ${renderUncertaintyNotes(data.uncertainty_notes)}
 
-      <div class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
+      <div id="boundary-sections-${data.run_id}" class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
         ${renderSection("Assumptions", assumptionCards, assumptionCards.length > 5)}
         ${renderSection("Decisions", decisionCards, decisionCards.length > 5)}
         ${renderSection("Detours", detourCards)}
@@ -309,6 +309,7 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-controls="boundary-sections-${data.run_id}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -273,7 +273,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       ${renderSummaryBar(data)}
       ${renderUncertaintyNotes(data.uncertainty_notes)}
 
-      <div class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
+      <div id="boundary-sections-${data.run_id}" class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
         ${renderSection("Assumptions", assumptionCards, assumptionCards.length > 5)}
         ${renderSection("Decisions", decisionCards, decisionCards.length > 5)}
         ${renderSection("Detours", detourCards)}
@@ -345,6 +345,7 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
     }
   });
 }


### PR DESCRIPTION
🎨 Palette: Improve accessibility of boundary review toggle

💡 What
Added `aria-expanded` and `aria-controls` attributes to the boundary review expand/collapse button, and synced the `aria-expanded` state during toggle interactions.

🎯 Why
Custom expand/collapse toggle buttons without appropriate ARIA attributes leave screen reader users unaware of the component's state or the content it controls, resulting in a confusing navigation experience.

📸 Before/After
N/A - Structural accessibility change only, visual appearance remains identical.

♿ Accessibility
- Added `aria-expanded` attribute synced with the expanded/collapsed state to announce changes to assistive technology.
- Added `aria-controls` mapped to the ID of the collapsible sections container to provide structural context.

---
*PR created automatically by Jules for task [7005389780128858126](https://jules.google.com/task/7005389780128858126) started by @EffortlessSteven*