### PR TITLE
⚡ Bolt: Optimize paginated run list endpoint for flow key filtering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+## 2026-05-05 - Streaming Filtered Pagination
+**Learning:** Slicing raw unfiltered collections breaks pagination offsets, but resolving filtering by loading and sorting all objects into memory just to return a small slice is an inefficient memory anti-pattern. We can iterate through the unfiltered IDs, evaluate the condition dynamically, track skipped offsets and limits, and accumulate matches without allocating large lists.
+**Action:** Always optimize paginated lists by combining offset skipping and limit tracking directly into the filter evaluation loop instead of delegating to full-fetch bulk list methods.

--- a/swarm/runtime/service.py
+++ b/swarm/runtime/service.py
@@ -293,11 +293,6 @@ class RunService:
             - List of run summaries for the requested page.
             - Total count of matching runs (may slightly overestimate).
         """
-        # Slow path if filtering by flow_key (cannot optimize without index)
-        if flow_key is not None:
-            all_runs = self.list_runs(flow_key, include_legacy, include_examples)
-            return all_runs[offset : offset + limit], len(all_runs)
-
         # Fast path: Work with IDs first, using set for deduplication
         seen_ids: set[str] = set()
         all_ids: List[str] = []
@@ -326,26 +321,56 @@ class RunService:
                 seen_ids.add(rid)
                 all_ids.append(rid)
 
-        total = len(all_ids)
-        sliced_ids = all_ids[offset : offset + limit]
-
         summaries = []
         # Create sets for fast lookups during summary creation
         example_set = set(storage.discover_example_runs()) if include_examples else set()
         legacy_set = set(legacy_ids)
 
-        for rid in sliced_ids:
-            summary = None
+        if flow_key is None:
+            total = len(all_ids)
+            sliced_ids = all_ids[offset : offset + limit]
 
-            if rid in example_set:
-                summary = self._create_legacy_summary(rid, is_example=True)
-            else:
-                summary = storage.read_summary(rid)
-                if not summary and rid in legacy_set:
-                    summary = self._create_legacy_summary(rid, is_example=False)
+            for rid in sliced_ids:
+                summary = None
 
-            if summary:
-                summaries.append(summary)
+                if rid in example_set:
+                    summary = self._create_legacy_summary(rid, is_example=True)
+                else:
+                    summary = storage.read_summary(rid)
+                    if not summary and rid in legacy_set:
+                        summary = self._create_legacy_summary(rid, is_example=False)
+
+                if summary:
+                    summaries.append(summary)
+        else:
+            # Optimized filtering path avoiding large memory allocations and full sorting
+            total = 0
+            skipped = 0
+
+            for rid in all_ids:
+                summary = None
+
+                if rid in example_set:
+                    summary = self._create_legacy_summary(rid, is_example=True)
+                else:
+                    summary = storage.read_summary(rid)
+                    if not summary and rid in legacy_set:
+                        summary = self._create_legacy_summary(rid, is_example=False)
+
+                if summary is None:
+                    continue
+
+                if flow_key not in summary.spec.flow_keys:
+                    continue
+
+                total += 1
+
+                if skipped < offset:
+                    skipped += 1
+                    continue
+
+                if len(summaries) < limit:
+                    summaries.append(summary)
 
         return summaries, total
 

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -533,6 +533,7 @@ class TestRunService:
         # Mock storage functions to use only our test runs
         run_ids = ["run-signal", "run-build"]
         monkeypatch.setattr(storage, "list_runs", lambda runs_dir=None: run_ids)
+        monkeypatch.setattr(storage, "scan_runs", lambda runs_dir=None: (run_ids, []))
         monkeypatch.setattr(storage, "discover_example_runs", lambda: [])
         monkeypatch.setattr(storage, "discover_legacy_runs", lambda runs_dir=None: [])
         orig_read_summary = storage.read_summary


### PR DESCRIPTION
⚡ Bolt: Optimize paginated run list endpoint for flow key filtering

💡 What: Replaced the slow path in `list_runs_paginated` that loads and sorts all run summaries into memory with an iterator-based stream that filters, counts matches, and tracks offsets dynamically.
🎯 Why: Using `self.list_runs` for pagination caused a massive memory allocation and redundant O(n log n) sorting just to return a small slice.
📊 Impact: Dramatically reduces memory usage when listing filtered runs, replacing a full in-memory list instantiation and sort with a constant-space limit-bounded accumulator.
🔬 Measurement: Run `uv run pytest tests/test_run_service.py` to verify that total counts and subset selection match the expected original logic.

---
*PR created automatically by Jules for task [2242990676104890365](https://jules.google.com/task/2242990676104890365) started by @EffortlessSteven*