### PR TITLE
🎨 Palette: Add aria-expanded to collapsible sections

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-05-05 - Missing aria-expanded on Flow Studio toggle buttons
+**Learning:** Found multiple instances of custom collapsible panels (Boundary Review, Routing Decisions) using chevron icons for toggling without updating `aria-expanded`. This is a common pattern in this app's components where visual state is maintained via classes but screen reader state is missing.
+**Action:** Always add `aria-expanded` binding to the toggle button's template and explicitly update `target.setAttribute("aria-expanded", String(isExpanded))` in the toggle event handler alongside chevron text content updates.

--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -309,6 +309,7 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", String(isExpanded));
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/js/components/RoutingDecisionCard.js
+++ b/swarm/tools/flow_studio_ui/js/components/RoutingDecisionCard.js
@@ -288,7 +288,7 @@ export class RoutingDecisionCard {
             .join("");
         return `
       <div class="routing-card__section routing-card__rejected ${expandedClass}">
-        <button class="routing-card__rejected-toggle" data-action="toggle-rejected">
+        <button class="routing-card__rejected-toggle" data-action="toggle-rejected" aria-expanded="${this.isExpanded}">
           <span class="routing-card__rejected-arrow">${arrowIcon}</span>
           <span>Other Candidates (${candidates.length})</span>
         </button>
@@ -686,6 +686,10 @@ export class RoutingDecisionCard {
         const arrow = section.querySelector(".routing-card__rejected-arrow");
         if (arrow) {
             arrow.textContent = this.isExpanded ? "\u25bc" : "\u25b6";
+        }
+        const toggleBtn = this.card.querySelector(".routing-card__rejected-toggle");
+        if (toggleBtn) {
+            toggleBtn.setAttribute("aria-expanded", String(this.isExpanded));
         }
     }
 }

--- a/swarm/tools/flow_studio_ui/pnpm-lock.yaml
+++ b/swarm/tools/flow_studio_ui/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.3: {}

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -345,6 +345,7 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", String(isExpanded));
     }
   });
 }

--- a/swarm/tools/flow_studio_ui/src/components/RoutingDecisionCard.ts
+++ b/swarm/tools/flow_studio_ui/src/components/RoutingDecisionCard.ts
@@ -441,7 +441,7 @@ export class RoutingDecisionCard {
 
     return `
       <div class="routing-card__section routing-card__rejected ${expandedClass}">
-        <button class="routing-card__rejected-toggle" data-action="toggle-rejected">
+        <button class="routing-card__rejected-toggle" data-action="toggle-rejected" aria-expanded="${this.isExpanded}">
           <span class="routing-card__rejected-arrow">${arrowIcon}</span>
           <span>Other Candidates (${candidates.length})</span>
         </button>
@@ -864,6 +864,11 @@ export class RoutingDecisionCard {
     );
     if (arrow) {
       arrow.textContent = this.isExpanded ? "\u25bc" : "\u25b6";
+    }
+
+    const toggleBtn = this.card.querySelector<HTMLElement>(".routing-card__rejected-toggle");
+    if (toggleBtn) {
+      toggleBtn.setAttribute("aria-expanded", String(this.isExpanded));
     }
   }
 }


### PR DESCRIPTION
"🎨 Palette: Add aria-expanded to collapsible sections\n\n💡 What: Added missing `aria-expanded` attributes to custom collapsible toggles in Boundary Review and Routing Decision Card components, ensuring they dynamically update when toggled.\n🎯 Why: Screen reader users previously had no way of knowing whether these sections were expanded or collapsed since state was only conveyed visually via chevron icons and CSS classes.\n📸 Before/After: Visual appearance is unchanged.\n♿ Accessibility: Ensures that dynamic toggle controls adhere to WAI-ARIA guidelines by exposing their state programmatically to assistive technologies."

---
*PR created automatically by Jules for task [7980493931633075868](https://jules.google.com/task/7980493931633075868) started by @EffortlessSteven*