### PR TITLE
🎨 Palette: Update toggle expand button accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-07 - Dynamic Aria Attributes
+**Learning:** Toggle buttons with dynamic states (expand/collapse) need their `aria-expanded`, `aria-label`, and `title` attributes to update dynamically to accurately reflect their state to screen readers.
+**Action:** Always bind accessibility attributes to the same boolean state (`isExpanded`) used for rendering the visual toggle icon.

--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="${isExpanded ? 'Collapse' : 'Expand'} boundary review" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-label="${isExpanded ? 'Collapse' : 'Expand'} boundary review">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="${isExpanded ? 'Collapse' : 'Expand'} boundary review" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-label="${isExpanded ? 'Collapse' : 'Expand'} boundary review">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>


### PR DESCRIPTION
🎨 Palette: Update toggle expand button accessibility

💡 What: Added dynamic `aria-expanded`, `aria-label`, and `title` attributes to the Boundary Review toggle button.
🎯 Why: The previous button only had a static 'Toggle expand' title and no aria attributes, making its current state (expanded vs collapsed) unclear to screen reader users.
📸 Before/After: Visual appearance remains unchanged, but screen readers now correctly announce 'Collapse boundary review' or 'Expand boundary review' along with the expanded state.
♿ Accessibility: Improves keyboard and screen reader accessibility by dynamically communicating the expanded/collapsed state to assistive technologies.

---
*PR created automatically by Jules for task [228320035479886480](https://jules.google.com/task/228320035479886480) started by @EffortlessSteven*