### PR TITLE
🎨 Palette: Synchronize aria-pressed with view toggle button states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-20 - Ensure aria-pressed syncs with view/mode toggle states
+**Learning:** Found that view toggle buttons ('Author' vs 'Operator', 'Steps/Agents' vs 'Artifacts') did not synchronize their `aria-pressed` state with the visual `active` CSS class.
+**Action:** Always verify that state toggle buttons manually synchronize `aria-pressed` alongside CSS class additions, ensuring keyboard and screen reader accessibility.

--- a/swarm/tools/flow_studio_ui/js/flow-studio-app.js
+++ b/swarm/tools/flow_studio_ui/js/flow-studio-app.js
@@ -252,10 +252,14 @@ function setMode(mode) {
     // Update toggle buttons
     const authorBtn = document.getElementById("mode-author");
     const operatorBtn = document.getElementById("mode-operator");
-    if (authorBtn)
+    if (authorBtn) {
         authorBtn.classList.toggle("active", mode === "author");
-    if (operatorBtn)
+        authorBtn.setAttribute("aria-pressed", mode === "author" ? "true" : "false");
+    }
+    if (operatorBtn) {
         operatorBtn.classList.toggle("active", mode === "operator");
+        operatorBtn.setAttribute("aria-pressed", mode === "operator" ? "true" : "false");
+    }
     // Update URL
     updateURL();
     // Refresh timeline display when switching to operator mode
@@ -275,10 +279,14 @@ async function setViewMode(viewMode) {
     // Update toggle buttons
     const agentsBtn = document.getElementById("view-agents");
     const artifactsBtn = document.getElementById("view-artifacts");
-    if (agentsBtn)
+    if (agentsBtn) {
         agentsBtn.classList.toggle("active", viewMode === "agents");
-    if (artifactsBtn)
+        agentsBtn.setAttribute("aria-pressed", viewMode === "agents" ? "true" : "false");
+    }
+    if (artifactsBtn) {
         artifactsBtn.classList.toggle("active", viewMode === "artifacts");
+        artifactsBtn.setAttribute("aria-pressed", viewMode === "artifacts" ? "true" : "false");
+    }
     // Update URL
     updateURL();
     // Reload graph with new view mode if we have a flow selected
@@ -371,10 +379,14 @@ function initMode() {
         state.currentViewMode = "artifacts";
         const agentsBtn = document.getElementById("view-agents");
         const artifactsBtn = document.getElementById("view-artifacts");
-        if (agentsBtn)
+        if (agentsBtn) {
             agentsBtn.classList.remove("active");
-        if (artifactsBtn)
+            agentsBtn.setAttribute("aria-pressed", "false");
+        }
+        if (artifactsBtn) {
             artifactsBtn.classList.add("active");
+            artifactsBtn.setAttribute("aria-pressed", "true");
+        }
     }
 }
 /**

--- a/swarm/tools/flow_studio_ui/pnpm-lock.yaml
+++ b/swarm/tools/flow_studio_ui/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.3: {}

--- a/swarm/tools/flow_studio_ui/src/flow-studio-app.ts
+++ b/swarm/tools/flow_studio_ui/src/flow-studio-app.ts
@@ -402,8 +402,8 @@ function setMode(mode: UIMode): void {
   // Update toggle buttons
   const authorBtn = document.getElementById("mode-author");
   const operatorBtn = document.getElementById("mode-operator");
-  if (authorBtn) authorBtn.classList.toggle("active", mode === "author");
-  if (operatorBtn) operatorBtn.classList.toggle("active", mode === "operator");
+  if (authorBtn) { authorBtn.classList.toggle("active", mode === "author"); authorBtn.setAttribute("aria-pressed", mode === "author" ? "true" : "false"); }
+  if (operatorBtn) { operatorBtn.classList.toggle("active", mode === "operator"); operatorBtn.setAttribute("aria-pressed", mode === "operator" ? "true" : "false"); }
 
   // Update URL
   updateURL();
@@ -427,8 +427,8 @@ async function setViewMode(viewMode: ViewMode): Promise<void> {
   // Update toggle buttons
   const agentsBtn = document.getElementById("view-agents");
   const artifactsBtn = document.getElementById("view-artifacts");
-  if (agentsBtn) agentsBtn.classList.toggle("active", viewMode === "agents");
-  if (artifactsBtn) artifactsBtn.classList.toggle("active", viewMode === "artifacts");
+  if (agentsBtn) { agentsBtn.classList.toggle("active", viewMode === "agents"); agentsBtn.setAttribute("aria-pressed", viewMode === "agents" ? "true" : "false"); }
+  if (artifactsBtn) { artifactsBtn.classList.toggle("active", viewMode === "artifacts"); artifactsBtn.setAttribute("aria-pressed", viewMode === "artifacts" ? "true" : "false"); }
 
   // Update URL
   updateURL();
@@ -542,8 +542,8 @@ function initMode(): void {
     state.currentViewMode = "artifacts";
     const agentsBtn = document.getElementById("view-agents");
     const artifactsBtn = document.getElementById("view-artifacts");
-    if (agentsBtn) agentsBtn.classList.remove("active");
-    if (artifactsBtn) artifactsBtn.classList.add("active");
+    if (agentsBtn) { agentsBtn.classList.remove("active"); agentsBtn.setAttribute("aria-pressed", "false"); }
+    if (artifactsBtn) { artifactsBtn.classList.add("active"); artifactsBtn.setAttribute("aria-pressed", "true"); }
   }
 }
 


### PR DESCRIPTION
🎨 Palette: Synchronize aria-pressed with view toggle button states\n\n💡 What: Updated the Author/Operator and Steps/Agents/Artifacts toggle buttons to manually synchronize their `aria-pressed` attribute with their visual `active` state class.\n🎯 Why: The buttons were visually updating via the `active` class but their `aria-pressed` accessibility states were not updating to reflect this status for screen readers.\n📸 Before/After: Visual presentation is identical, but inspecting the DOM elements will reveal correct `aria-pressed` values.\n♿ Accessibility: Screen readers will now correctly report whether the author mode or artifacts view is currently toggled on.\n✅ Verification: Verified locally via `pnpm run ts-check`. No targeted tests exist in this repo for these buttons, so verification was limited to linting, build, and manual visual inspection via playwright.

---
*PR created automatically by Jules for task [6925338975104151277](https://jules.google.com/task/6925338975104151277) started by @EffortlessSteven*