### PR TITLE
⚡ Bolt: Optimize large directory traversals with os.scandir

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+## 2026-05-08 - Optimized directory traversal with os.scandir
+**Learning:** Iterating large directories using `Path.iterdir()` with `is_dir()` and `.name` introduces excessive system stat overhead by continuously creating Python Path objects and invoking `stat()` calls. For massive directories like thousands of run histories, this is a significant bottleneck.
+**Action:** Used `os.scandir()` instead, which correctly avoids duplicate internal stat operations by relying on the OS's native metadata cache, yielding massive speed improvements for simple filtering steps and discovery.

--- a/swarm/flowstudio/config.py
+++ b/swarm/flowstudio/config.py
@@ -6,6 +6,7 @@ This creates a seam for future extraction into a standalone package
 while keeping the current single-repo structure.
 """
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
@@ -131,17 +132,21 @@ class FlowStudioConfig:
         """List all active runs."""
         if not self.runs_dir.exists():
             return []
-        return sorted(
-            p for p in self.runs_dir.iterdir() if p.is_dir() and not p.name.startswith(".")
-        )
+        # PERFORMANCE: Use os.scandir instead of iterdir() + is_dir() to avoid stat overhead
+        with os.scandir(self.runs_dir) as it:
+            return sorted(
+                Path(entry.path) for entry in it if entry.is_dir() and not entry.name.startswith(".")
+            )
 
     def list_examples(self) -> list[Path]:
         """List all example runs."""
         if not self.examples_dir.exists():
             return []
-        return sorted(
-            p for p in self.examples_dir.iterdir() if p.is_dir() and not p.name.startswith(".")
-        )
+        # PERFORMANCE: Use os.scandir instead of iterdir() + is_dir() to avoid stat overhead
+        with os.scandir(self.examples_dir) as it:
+            return sorted(
+                Path(entry.path) for entry in it if entry.is_dir() and not entry.name.startswith(".")
+            )
 
 
 # Default config instance (lazily constructed)

--- a/swarm/runtime/statsdb/rebuild.py
+++ b/swarm/runtime/statsdb/rebuild.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -129,9 +130,11 @@ class StatsDBRebuildMixin:
                 logger.warning("Runs directory does not exist: %s", runs_dir)
                 return stats
 
-            run_ids = [
-                d.name for d in runs_dir.iterdir() if d.is_dir() and not d.name.startswith(".")
-            ]
+            # PERFORMANCE: Use os.scandir instead of iterdir() + is_dir() to avoid stat overhead
+            with os.scandir(runs_dir) as it:
+                run_ids = [
+                    entry.name for entry in it if entry.is_dir() and not entry.name.startswith(".")
+                ]
 
         logger.info("Rebuilding projections for %d runs", len(run_ids))
 
@@ -236,7 +239,9 @@ def rebuild_stats_db(
             logger.warning("Runs directory does not exist: %s", runs_dir)
             return stats
 
-        run_ids = [d.name for d in runs_dir.iterdir() if d.is_dir() and not d.name.startswith(".")]
+        # PERFORMANCE: Use os.scandir instead of iterdir() + is_dir() to avoid stat overhead
+        with os.scandir(runs_dir) as it:
+            run_ids = [entry.name for entry in it if entry.is_dir() and not entry.name.startswith(".")]
 
     logger.info("Rebuilding stats DB from %d runs", len(run_ids))
 
@@ -278,43 +283,46 @@ def rebuild_stats_db(
             # Set ingestion context to allow record_* calls (projection-only mode)
             _ingestion_context.active = True
             try:
-                for flow_dir in run_path.iterdir():
-                    if not flow_dir.is_dir() or flow_dir.name.startswith("."):
-                        continue
+                # PERFORMANCE: Use os.scandir instead of iterdir() + is_dir() to avoid stat overhead
+                with os.scandir(run_path) as it:
+                    for entry in it:
+                        if not entry.is_dir() or entry.name.startswith("."):
+                            continue
+                        flow_dir = Path(entry.path)
 
-                    handoff_dir = flow_dir / "handoff"
-                    if not handoff_dir.exists():
-                        continue
+                        handoff_dir = flow_dir / "handoff"
+                        if not handoff_dir.exists():
+                            continue
 
-                    for envelope_file in handoff_dir.glob("*.json"):
-                        try:
-                            with envelope_file.open("r", encoding="utf-8") as f:
-                                envelope_data = json.load(f)
+                        for envelope_file in handoff_dir.glob("*.json"):
+                            try:
+                                with envelope_file.open("r", encoding="utf-8") as f:
+                                    envelope_data = json.load(f)
 
-                            # Record file changes from envelope if present
-                            file_changes = envelope_data.get("file_changes", {})
-                            if file_changes and "files" in file_changes:
-                                step_id = envelope_data.get("step_id", envelope_file.stem)
-                                for fc in file_changes.get("files", []):
-                                    db.record_file_change(
-                                        run_id=run_id,
-                                        step_id=step_id,
-                                        file_path=fc.get("path", ""),
-                                        change_type=fc.get("status", "modified"),
-                                        lines_added=fc.get("insertions", 0),
-                                        lines_removed=fc.get("deletions", 0),
-                                    )
+                                # Record file changes from envelope if present
+                                file_changes = envelope_data.get("file_changes", {})
+                                if file_changes and "files" in file_changes:
+                                    step_id = envelope_data.get("step_id", envelope_file.stem)
+                                    for fc in file_changes.get("files", []):
+                                        db.record_file_change(
+                                            run_id=run_id,
+                                            step_id=step_id,
+                                            file_path=fc.get("path", ""),
+                                            change_type=fc.get("status", "modified"),
+                                            lines_added=fc.get("insertions", 0),
+                                            lines_removed=fc.get("deletions", 0),
+                                        )
 
-                            stats["envelopes_processed"] += 1
+                                stats["envelopes_processed"] += 1
 
-                        except (json.JSONDecodeError, IOError) as e:
-                            stats["errors"].append(
-                                {
-                                    "run_id": run_id,
-                                    "file": str(envelope_file),
-                                    "error": str(e),
-                                }
-                            )
+                            except (json.JSONDecodeError, IOError) as e:
+                                stats["errors"].append(
+                                    {
+                                        "run_id": run_id,
+                                        "file": str(envelope_file),
+                                        "error": str(e),
+                                    }
+                                )
             finally:
                 _ingestion_context.active = False
 


### PR DESCRIPTION
⚡ Bolt: Optimize large directory traversals with os.scandir
💡 What: Replaced usages of `Path.iterdir()` with `os.scandir()` in `swarm/flowstudio/config.py` and `swarm/runtime/statsdb/rebuild.py`.
🎯 Why: `os.scandir()` caches metadata like `.is_dir()` and `.name`, avoiding the massive system overhead involved with creating `Path` objects and making repetitive `stat()` calls in environments with many directories.
📊 Impact: Considerably faster scanning and stat fetching for directories with many items (e.g. `list_runs` iterating over thousands of runs).
🔬 Measurement: Verified the improvement doesn't break behaviour through pytest coverage. We can verify the execution speed over massive directories by checking the duration reduction in traversing lists.

---
*PR created automatically by Jules for task [3692276917382139147](https://jules.google.com/task/3692276917382139147) started by @EffortlessSteven*