### PR TITLE
🎨 Palette: Add accessibility attributes to Boundary Review toggle button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-08 - Accessible Expand/Collapse Buttons
+**Learning:** Icon-only expand/collapse buttons (like "▼" or "▶") are opaque to screen readers without proper attributes. They require `aria-expanded` to indicate state, `aria-controls` to link to the controlled region, and `aria-label` to clearly state their action.
+**Action:** Always pair visual state indicators on toggle buttons with programmatic `aria-expanded` attributes, and ensure they have descriptive `aria-label`s when lacking visible text.

--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" aria-expanded="${isExpanded}" aria-controls="boundary-sections-${data.run_id}" aria-label="${isExpanded ? "Collapse boundary review" : "Expand boundary review"}" title="Toggle expand">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -244,7 +244,7 @@ export function renderBoundaryReviewPanel(data) {
       ${renderSummaryBar(data)}
       ${renderUncertaintyNotes(data.uncertainty_notes)}
 
-      <div class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
+      <div id="boundary-sections-${data.run_id}" class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
         ${renderSection("Assumptions", assumptionCards, assumptionCards.length > 5)}
         ${renderSection("Decisions", decisionCards, decisionCards.length > 5)}
         ${renderSection("Detours", detourCards)}
@@ -300,8 +300,8 @@ export function toggleExpanded() {
 export function setupBoundaryReviewHandlers(container) {
     // Toggle expand button
     container.addEventListener("click", (e) => {
-        const target = e.target;
-        if (target.classList.contains("toggle-expand")) {
+        const target = e.target.closest('.toggle-expand');
+        if (target) {
             toggleExpanded();
             const sections = container.querySelector(".boundary-sections");
             if (sections) {
@@ -309,6 +309,8 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", String(isExpanded));
+            target.setAttribute("aria-label", isExpanded ? "Collapse boundary review" : "Expand boundary review");
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/pnpm-lock.yaml
+++ b/swarm/tools/flow_studio_ui/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.3: {}

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" aria-expanded="${isExpanded}" aria-controls="boundary-sections-${data.run_id}" aria-label="${isExpanded ? "Collapse boundary review" : "Expand boundary review"}" title="Toggle expand">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -273,7 +273,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       ${renderSummaryBar(data)}
       ${renderUncertaintyNotes(data.uncertainty_notes)}
 
-      <div class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
+      <div id="boundary-sections-${data.run_id}" class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
         ${renderSection("Assumptions", assumptionCards, assumptionCards.length > 5)}
         ${renderSection("Decisions", decisionCards, decisionCards.length > 5)}
         ${renderSection("Detours", detourCards)}
@@ -336,8 +336,8 @@ export function toggleExpanded(): void {
 export function setupBoundaryReviewHandlers(container: HTMLElement): void {
   // Toggle expand button
   container.addEventListener("click", (e) => {
-    const target = e.target as HTMLElement;
-    if (target.classList.contains("toggle-expand")) {
+    const target = (e.target as HTMLElement).closest('.toggle-expand');
+    if (target) {
       toggleExpanded();
       const sections = container.querySelector(".boundary-sections");
       if (sections) {
@@ -345,6 +345,8 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", String(isExpanded));
+      target.setAttribute("aria-label", isExpanded ? "Collapse boundary review" : "Expand boundary review");
     }
   });
 }


### PR DESCRIPTION
🎨 Palette: Add accessibility attributes to Boundary Review toggle button\n\n💡 What: Added aria-expanded, aria-controls, and aria-label to the Boundary Review panel's toggle button.\n🎯 Why: The icon-only button ("▼" or "▶") was inaccessible to screen readers, providing no context about its purpose or state.\n♿ Accessibility: Screen reader users can now understand the button controls the boundary review section and whether it is currently expanded or collapsed.\n\n✅ Verification: No targeted tests exist and verification was limited to linting and manual inspection.

---
*PR created automatically by Jules for task [1491042651924891352](https://jules.google.com/task/1491042651924891352) started by @EffortlessSteven*