### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XML External Entity (XXE) Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-09 - [XML External Entity (XXE) Vulnerability]
+**Vulnerability:** [Usage of standard `xml.etree.ElementTree` parsing without protection against XXE attacks]
+**Learning:** [Standard XML parsing libraries are vulnerable to XXE by default. In `swarm/runtime/test_parser.py`, parsing untrusted JUnit XML test results with `ET.parse()` could expose the system to XXE.]
+**Prevention:** [Always use secure alternatives like `defusedxml` when parsing XML to prevent external entity injection.]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Security updates for medium-priority vulnerabilities
     "starlette>=0.46.0,<1.0.0",
     "urllib3>=2.3.0,<3.0.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/swarm/runtime/test_parser.py
+++ b/swarm/runtime/test_parser.py
@@ -35,11 +35,13 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+# SECURITY: Mitigating XML External Entity (XXE) vulnerabilities using defusedxml
+import defusedxml.ElementTree as ET
 
 from swarm.runtime.forensic_types import (
     FailureType,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -358,6 +368,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5,<2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0" },
     { name = "claude-agent-sdk", marker = "extra == 'dev'", specifier = ">=0.1.19" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix XML External Entity (XXE) Vulnerability

🚨 Severity: CRITICAL
💡 Vulnerability: Usage of standard `xml.etree.ElementTree` parsing without protection against XML External Entity (XXE) attacks in `swarm/runtime/test_parser.py`.
🎯 Impact: Parsing untrusted JUnit XML test results using the vulnerable `ET.parse()` could expose the system to XXE injection, potentially leading to arbitrary local file disclosure, server-side request forgery (SSRF), or denial of service (Billion Laughs attack).
🔧 Fix: Added the `defusedxml` dependency via `uv add defusedxml` and replaced the standard `xml.etree.ElementTree` import with `defusedxml.ElementTree` as a drop-in replacement to safely parse XML data. A critical security learning entry was also added to `.jules/sentinel.md`.
✅ Verification: Ran `ruff check` on the modified file to ensure formatting constraints were met, and executed parser-related tests (`pytest tests/test_yaml_parser.py` and `pytest tests/test_run_inspector.py`) to confirm no regressions were introduced.

---
*PR created automatically by Jules for task [11171519887096234313](https://jules.google.com/task/11171519887096234313) started by @EffortlessSteven*