### PR TITLE
🎨 Palette: Add ARIA states to Boundary Review expand toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-05-10 - Dynamic ARIA States in Vanilla JS Components
+**Learning:** Dynamically rendered components constructed with template literals easily drop ARIA state synchronization because their HTML strings don't automatically bind to state variables like `isExpanded`.
+**Action:** When adding ARIA states (like `aria-expanded`) to dynamic templates, always ensure the event listener explicitly updates the DOM attributes (`setAttribute`) alongside the textual/visual changes.

--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded}" aria-label="${isExpanded ? 'Collapse review section' : 'Expand review section'}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -309,6 +309,8 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", String(isExpanded));
+            target.setAttribute("aria-label", isExpanded ? "Collapse review section" : "Expand review section");
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded}" aria-label="${isExpanded ? 'Collapse review section' : 'Expand review section'}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -345,6 +345,8 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", String(isExpanded));
+      target.setAttribute("aria-label", isExpanded ? "Collapse review section" : "Expand review section");
     }
   });
 }


### PR DESCRIPTION
🎨 Palette: Add ARIA states to Boundary Review expand toggle

💡 What: Added aria-expanded and aria-label attributes to the Boundary Review toggle button, and ensured they update correctly when clicked.
🎯 Why: The icon-only button lacks a clear accessible name and fails to announce its collapsed/expanded state to screen readers.
♿ Accessibility: Screen reader users will now hear the expand/collapse state and the purpose of the button.

---
*PR created automatically by Jules for task [2441438892568280927](https://jules.google.com/task/2441438892568280927) started by @EffortlessSteven*