### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent eval and exec in production code

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-05-11 - Prevent eval and exec in production
+**Vulnerability:** Code injection via `eval` and `exec`.
+**Learning:** `eval` and `exec` were not explicitly forbidden by test guardrails, leaving the codebase vulnerable to accidental introduction of code injection risks.
+**Prevention:** Added `test_eval_exec_guardrail.py` to block `eval()` and `exec()` in production code.

--- a/tests/test_eval_exec_guardrail.py
+++ b/tests/test_eval_exec_guardrail.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIRS = [
+    REPO_ROOT / "swarm",
+    REPO_ROOT / "packages" / "selftest-core" / "src",
+]
+PATTERN = re.compile(r"\b(eval|exec)\s*\(")
+
+# If you ever must allow a specific file, add its repo-relative posix path here.
+ALLOWLIST: set[str] = set()
+
+
+def test_no_eval_exec_in_production_code() -> None:
+    hits: list[str] = []
+    for base in SCAN_DIRS:
+        if not base.exists():
+            continue
+        for path in base.rglob("*.py"):
+            rel = path.relative_to(REPO_ROOT).as_posix()
+            if rel in ALLOWLIST:
+                continue
+            text = path.read_text(encoding="utf-8", errors="ignore")
+            for m in PATTERN.finditer(text):
+                line = text.count("\n", 0, m.start()) + 1
+                hits.append(f"{rel}:{line}")
+    assert not hits, "eval() and exec() are forbidden in production code:\n" + "\n".join(hits)


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The codebase lacked a test constraint explicitly preventing the use of `eval()` and `exec()`, leaving it open to code injection if dynamically loaded code or data is ever passed to these unsafe functions.
🎯 **Impact**: If an attacker can control strings passed to `eval` or `exec` in production, they could execute arbitrary Python code, gaining full system access.
🔧 **Fix**: Added `tests/test_eval_exec_guardrail.py` to scan `swarm/` and `packages/` for `eval()` or `exec()`. Removed an unused variable in boundary enforcement. Logged a Sentinel learning.
✅ **Verification**: Run `uv run pytest tests/test_eval_exec_guardrail.py` to verify it passes locally.

---
*PR created automatically by Jules for task [5500450874403887796](https://jules.google.com/task/5500450874403887796) started by @EffortlessSteven*