### PR TITLE
spec: define repo-native spec namespace

### DIFF
--- a/.flow-studio-swarm-spec/README.md
+++ b/.flow-studio-swarm-spec/README.md
@@ -1,0 +1,26 @@
+# flow-studio-swarm Durable Spec Namespace
+
+This directory is the durable, repo-owned source of truth for proposal/spec/ADR/lane/closeout rails.
+
+## Ownership
+
+Owned by this repository's long-term control-plane method:
+
+- `proposals/` for problem framing and product rationale.
+- `specs/` for behavior contracts and required evidence.
+- `adr/` for durable architecture decisions.
+- `lanes/` for focused implementation trackers and execution plans.
+- `support/` for claim-to-proof mapping (or references).
+- `policy/` for references to live `policy/*.toml` ledgers.
+- `closeouts/` for durable memory of what landed and what remains.
+
+## External/tool namespaces
+
+The following directories may exist in the repo, but they are awareness-only for this system:
+
+- `.codex/`
+- `.spec/`
+- `.claude/`
+- `.jules/`
+
+This namespace does not own or mutate tool-specific scratch or session state.

--- a/.flow-studio-swarm-spec/index.toml
+++ b/.flow-studio-swarm-spec/index.toml
@@ -1,0 +1,16 @@
+schema_version = "1.0"
+
+repo = "flow-studio-swarm"
+namespace = ".flow-studio-swarm-spec"
+
+[conventions]
+proposal_prefix = "FSS-PROP"
+spec_prefix = "FSS-SPEC"
+adr_prefix = "FSS-ADR"
+lane_prefix = "FSS-LANE"
+
+[external_namespaces]
+codex = ".codex"
+speckit = ".spec"
+claude = ".claude"
+jules = ".jules"

--- a/docs/contributing/spec-rails.md
+++ b/docs/contributing/spec-rails.md
@@ -1,0 +1,28 @@
+# Contributing: Repo-Native Spec Rails
+
+Use `.flow-studio-swarm-spec/` as the durable knowledge base for long-lived planning and contract artifacts.
+
+## Owned scope
+
+- `.flow-studio-swarm-spec/`
+- `docs/spec-style.md`
+- `docs/contributing/spec-rails.md`
+- `policy/*.toml` only when referencing existing live ledgers
+- `plans/` only when already part of the repo's non-agent planning surface
+
+## Do not treat as durable rails
+
+- `.codex/`
+- `.spec/`
+- `.claude/`
+- `.jules/`
+
+These are external/tool-specific state for this lane.
+
+## Contribution checklist
+
+1. Add or update durable artifacts under `.flow-studio-swarm-spec/`.
+2. Ensure all durable artifacts are linked through `.flow-studio-swarm-spec/index.toml` conventions.
+3. Keep proposal/spec/ADR/lane/closeout responsibilities separate.
+4. Reference policy/support sources instead of duplicating them.
+5. Avoid introducing durable ownership claims for tool-state directories.

--- a/docs/spec-style.md
+++ b/docs/spec-style.md
@@ -1,0 +1,47 @@
+# Spec Style and Source-of-Truth Stack
+
+This repository keeps a full source-of-truth stack, with each artifact owning one layer of intent:
+
+- Roadmap
+- Proposal / PRD
+- Spec
+- ADR
+- Lane tracker / implementation plan
+- PRs and proof commands
+- Support-tier and policy references
+- Closeout
+
+## Durable home
+
+Durable rails live under:
+
+- `.flow-studio-swarm-spec/`
+
+Human-facing explanation and contribution guidance live under:
+
+- `docs/`
+
+Live enforcement ledgers remain under:
+
+- `policy/` (when present)
+
+## External state boundaries
+
+The following directories are external/tool-specific state and are not durable spec rails:
+
+- `.codex/`
+- `.spec/`
+- `.claude/`
+- `.jules/`
+
+Agents may read the durable namespace, but this spec style does not manage agent scratch state.
+
+## Separation rule
+
+Do not collapse proposal, spec, tasks, release proof, and policy into one file. Keep artifacts separated by responsibility:
+
+- Proposal explains why and success criteria.
+- Spec defines required behavior and evidence.
+- ADR records durable architecture decisions.
+- Lane artifacts define PR-sized execution state.
+- Closeouts capture what happened and what remains.


### PR DESCRIPTION
### Motivation

- Establish a durable, repo-owned source-of-truth for proposals, specs, ADRs, lane trackers, support/policy references, and closeouts instead of storing durable rails in agent/tool-specific scratch areas.
- Make it explicit that tool/session directories like `.codex`, `.spec`, `.claude`, and `.jules` are awareness-only and not owned by the durable spec system.

### Description

- Add `.flow-studio-swarm-spec/README.md` which defines ownership (proposals, specs, ADRs, lanes, support, policy, closeouts) and marks external/tool namespaces as awareness-only.
- Add `.flow-studio-swarm-spec/index.toml` with repo metadata, artifact ID prefixes, and `[external_namespaces]` entries pointing at `.codex`, `.spec`, `.claude`, and `.jules`.
- Add `docs/spec-style.md` documenting the source-of-truth stack and the separation rule for proposal/spec/ADR/plan/proof/closeout responsibilities.
- Add `docs/contributing/spec-rails.md` with contributor-facing scope, non-owned tool-state boundaries, and a short contribution checklist.

### Testing

- Ran `git diff --check` which reported no problems and succeeded.
- Verified repository state with `git status --short` and committed the changes via `git commit -m "spec: define repo-native spec namespace"` which completed successfully.
- No unit or runtime tests were required for these documentation and metadata files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ebe14bc18833382a32a0d4e3c8942)