### PR TITLE
Add CI runner routing guard and wire into guardrails job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
         if: github.event_name == 'pull_request'
         run: make complexity-check
 
+      - name: Check runner routing guard
+        run: make runner-routing-guard
+
       - name: Lint routing fields (strict)
         run: make lint-routing-strict
 

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,10 @@ lint-routing:
 	@echo "Checking for deprecated routing field patterns..."
 	uv run python swarm/tools/lint_routing_fields.py
 
+.PHONY: runner-routing-guard
+runner-routing-guard:
+	@./swarm/tools/check_runner_routing_guard.sh
+
 .PHONY: lint-routing-strict
 lint-routing-strict:
 	@echo "Checking for deprecated routing field patterns (strict mode)..."

--- a/swarm/tools/check_runner_routing_guard.sh
+++ b/swarm/tools/check_runner_routing_guard.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow_dir="${1:-.github/workflows}"
+bad=0
+
+if [[ ! -d "$workflow_dir" ]]; then
+  echo "Workflow directory not found: $workflow_dir" >&2
+  exit 2
+fi
+
+echo "Checking GitHub Actions runner routing in $workflow_dir..."
+
+if rg -n --glob '*.yml' --glob '*.yaml' 'runs-on:[[:space:]]*\[[^]]*self-hosted[^]]*linux[^]]*x64[^]]*\]' "$workflow_dir"; then
+  echo "Bare inline self-hosted/linux/x64 runs-on is forbidden." >&2
+  bad=1
+fi
+
+if rg -n --glob '*.yml' --glob '*.yaml' 'repos/[^[:space:]"'"'"']+/[^[:space:]"'"'"']+/actions/runners' "$workflow_dir"; then
+  echo "Repository runner discovery is forbidden; use orgs/EffortlessMetrics/actions/runners?per_page=100." >&2
+  bad=1
+fi
+
+while IFS=: read -r file line _; do
+  window="$(sed -n "${line},$((line+16))p" "$file")"
+
+  if printf '%s\n' "$window" | rg -q '^[[:space:]]*-[[:space:]]*linux[[:space:]]*$' &&
+     printf '%s\n' "$window" | rg -q '^[[:space:]]*-[[:space:]]*x64[[:space:]]*$' &&
+     ! printf '%s\n' "$window" | rg -q 'group:[[:space:]]*em-ci-' &&
+     ! printf '%s\n' "$window" | rg -q '^[[:space:]]*-[[:space:]]*(em-ci|ci-nano|policy-nano|workflow-nano|rust-tiny|rust-medium|rust-large|rust-16gb|cx23|cx33|cx43|cx53|cpx42)[[:space:]]*$'; then
+    echo "$file:$line: bare self-hosted block lacks group/capacity labels" >&2
+    bad=1
+  fi
+done < <(rg -n --glob '*.yml' --glob '*.yaml' '^[[:space:]]*-[[:space:]]*self-hosted[[:space:]]*$' "$workflow_dir" || true)
+
+if [[ "$bad" -eq 0 ]]; then
+  echo "✓ Runner routing guard passed"
+fi
+
+exit "$bad"


### PR DESCRIPTION
### Motivation

- Prevent workflows from accidentally targeting bare self-hosted `linux/x64` runners or using repository-scoped runner discovery, enforcing the em-ci group/capacity routing contract.
- Catch routing mistakes early in CI so repos adopt the fleet routing rules without sending heavy jobs to the wrong machines.

### Description

- Add `swarm/tools/check_runner_routing_guard.sh`, a bash guard that fails on bare `runs-on: [self-hosted, linux, x64]` patterns, repository runner discovery (`repos/.../actions/runners`), and self-hosted blocks that lack explicit `group`/capacity labels. 
- Add a `runner-routing-guard` Makefile target that invokes the guard script. 
- Wire the Makefile target into the CI guardrails job in `.github/workflows/ci.yml` so the check runs as part of the existing validation steps before routing linting. 
- The guard emits human-friendly diagnostics and returns a non-zero exit code on violations to block the CI step. 

### Testing

- Performed a shell syntax check with `bash -n swarm/tools/check_runner_routing_guard.sh` which succeeded. 
- Executed `make runner-routing-guard` which ran the script and reported `✓ Runner routing guard passed`. 
- Parsed all workflow YAML files with a Python `yaml.safe_load(...)` script to ensure no parsing regressions. 
- Ran `git diff --check` to verify no whitespace or formatting errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c17674a6c8333bace3d673cef1fc7)