### PR TITLE
Add Droid PR Review workflow configured for MiniMax-M3

### DIFF
--- a/.github/workflows/droid-pr-review.yml
+++ b/.github/workflows/droid-pr-review.yml
@@ -1,0 +1,59 @@
+name: Droid PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: droid-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  droid-review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Configure MiniMax M3 for Droid BYOK
+        shell: bash
+        run: |
+          mkdir -p "$HOME/.factory"
+
+          cat > "$HOME/.factory/settings.json" <<'JSON'
+          {
+            "customModels": [
+              {
+                "model": "MiniMax-M3",
+                "displayName": "MiniMax-M3",
+                "baseUrl": "https://api.minimax.io/anthropic",
+                "apiKey": "${MINIMAX_API_KEY}",
+                "provider": "anthropic",
+                "maxOutputTokens": 64000
+              }
+            ]
+          }
+          JSON
+
+      - name: Run Droid Auto Review
+        uses: Factory-AI/droid-action@main
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          ANTHROPIC_AUTH_TOKEN: ""
+          ANTHROPIC_BASE_URL: ""
+        with:
+          factory_api_key: ${{ secrets.FACTORY_API_KEY }}
+          automatic_review: true
+          review_model: custom:MiniMax-M3-0
+          automatic_security_review: true
+          security_model: custom:MiniMax-M3-0


### PR DESCRIPTION
### Motivation
- Provide a CI GitHub Actions workflow to run Factory's Droid PR review using the MiniMax M3 BYOK configuration so reviews are deterministic and use the Anthropic-compatible MiniMax endpoint, skipping draft PRs and using per-PR concurrency.

### Description
- Add `.github/workflows/droid-pr-review.yml` which writes `$HOME/.factory/settings.json` with a `MiniMax-M3` entry (`baseUrl: https://api.minimax.io/anthropic`, `apiKey: ${MINIMAX_API_KEY}`, `maxOutputTokens: 64000`) and invokes `Factory-AI/droid-action@main` with `review_model: custom:MiniMax-M3-0` and `security_model: custom:MiniMax-M3-0` while clearing `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL`.

### Testing
- Verified workflow wiring with inline Python assertions and a YAML parse check via `python - <<'PY'` checks that confirmed the presence of `review_model: custom:MiniMax-M3-0`, `security_model: custom:MiniMax-M3-0`, empty Anthropic globals, and that the workflow YAML parses successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d09daee94833386ed1438ce6e4d3f)