### PR TITLE
🎨 Palette: Add focus-visible states for custom toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-04 - Custom Toggle Focus States
+**Learning:** Custom toggle button groups (like `.mode-toggle`, `.view-toggle`, `.filter-btn`) often miss standard keyboard focus outlines compared to semantic utility buttons, hurting keyboard navigation accessibility.
+**Action:** Always ensure custom interactive elements have a clear `:focus-visible` style explicitly defined in CSS to maintain a11y standards.

--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -457,6 +457,10 @@
       background: #3b82f6;
       color: white;
     }
+    .mode-toggle button:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: -2px;
+    }
     .mode-toggle button:first-child {
       border-right: 1px solid #d1d5db;
     }
@@ -1023,6 +1027,10 @@
     .view-toggle button.active {
       background: #0f766e;
       color: white;
+    }
+    .view-toggle button:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: -2px;
     }
     .view-toggle button:first-child {
       border-right: 1px solid #d1d5db;
@@ -1896,6 +1904,12 @@
       transform: rotate(-90deg);
     }
 
+    .run-history-header .collapse-toggle:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
+
     .run-history-filter {
       display: flex;
       gap: var(--fs-spacing-xs);
@@ -1915,6 +1929,11 @@
 
     .run-history-filter .filter-btn:hover {
       border-color: var(--fs-color-accent);
+    }
+
+    .run-history-filter .filter-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
 
     .run-history-filter .filter-btn.active {
@@ -2225,6 +2244,11 @@
       background: #fef3c7;
       border-color: #f59e0b;
       color: #92400e;
+    }
+
+    .teaching-mode-toggle:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
 
     .teaching-mode-toggle.active .teaching-mode-icon {

--- a/swarm/tools/flow_studio_ui/pnpm-lock.yaml
+++ b/swarm/tools/flow_studio_ui/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+packages:
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.9.3: {}


### PR DESCRIPTION
🎨 Palette: Add focus-visible states for custom toggle buttons

💡 What: Added explicitly defined `:focus-visible` CSS rules to custom toggle components (`.mode-toggle`, `.view-toggle`, `.teaching-mode-toggle`, `.filter-btn`, `.collapse-toggle`).
🎯 Why: Keyboard users previously lacked clear visual feedback when tabbing through these toggle controls, making the UI harder to navigate without a mouse.
♿ Accessibility: Improved WCAG compliance by ensuring all interactive elements display a clear focus ring using the standard theme accent color.

---
*PR created automatically by Jules for task [7617686811309493254](https://jules.google.com/task/7617686811309493254) started by @EffortlessSteven*