### PR TITLE
🎨 Palette: Add keyboard focus visible states to all interactive elements

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-05 - Keyboard Accessibility for Custom Interactive Elements
+**Learning:** Custom buttons and toggles across the UI often lack proper `:focus-visible` states, severely hampering keyboard navigation.
+**Action:** Always ensure all interactive elements (buttons, toggles, close buttons, action links) explicitly define a `:focus-visible` state (preferring it over `:focus` to avoid visual clutter on mouse clicks) utilizing an `outline` to guarantee keyboard accessibility.

--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -170,6 +170,10 @@
     .fs-button-primary:hover {
       background: var(--fs-color-accent-hover, #2563eb);
     }
+    .fs-button-primary:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+    }
 
     html, body {
       margin: 0;
@@ -453,6 +457,12 @@
     .mode-toggle button:hover {
       background: #e5e7eb;
     }
+    .mode-toggle button:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: -2px;
+      position: relative;
+      z-index: 1;
+    }
     .mode-toggle button.active {
       background: #3b82f6;
       color: white;
@@ -588,6 +598,10 @@
     .tour-dropdown-btn:hover {
       background: #e5e7eb;
     }
+    .tour-dropdown-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+    }
     .tour-dropdown-btn.active {
       background: #dbeafe;
       border-color: #3b82f6;
@@ -667,6 +681,11 @@
     .tour-exit-btn:hover {
       color: #111827;
     }
+    .tour-exit-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
     .tour-card-title {
       font-weight: 600;
       font-size: 14px;
@@ -706,6 +725,10 @@
     .tour-nav-btn.primary:hover {
       background: #2563eb;
     }
+    .tour-nav-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+    }
     .tour-highlight {
       box-shadow: 0 0 0 3px #3b82f6, 0 0 20px rgba(59, 130, 246, 0.5) !important;
       z-index: 10 !important;
@@ -727,6 +750,10 @@
     }
     .governance-toggle:hover {
       background: #e5e7eb;
+    }
+    .governance-toggle:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
     .governance-toggle.active {
       background: #fef3c7;
@@ -1024,6 +1051,12 @@
       background: #0f766e;
       color: white;
     }
+    .view-toggle button:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: -2px;
+      position: relative;
+      z-index: 1;
+    }
     .view-toggle button:first-child {
       border-right: 1px solid #d1d5db;
     }
@@ -1253,6 +1286,10 @@
     .copy-btn:hover {
       background: #e5e7eb;
       border-color: #9ca3af;
+    }
+    .copy-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
     .copy-btn.copied {
       background: #d1fae5;
@@ -1506,6 +1543,11 @@
     .selftest-command-copy-btn:hover {
       color: #1e40af;
     }
+    .selftest-command-copy-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
     .selftest-modal-close {
       float: right;
       background: none;
@@ -1519,6 +1561,11 @@
     }
     .selftest-modal-close:hover {
       color: #111827;
+    }
+    .selftest-modal-close:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+      border-radius: 4px;
     }
     /* AC (Acceptance Criteria) badges */
     .selftest-ac-container {
@@ -1698,6 +1745,10 @@
     .fs-empty-action:hover {
       background: var(--fs-color-accent-hover);
     }
+    .fs-empty-action:focus-visible {
+      outline: 2px solid var(--fs-color-accent);
+      outline-offset: 2px;
+    }
     .fs-empty-command {
       font-size: 11px;
       padding: 4px 8px;
@@ -1754,6 +1805,10 @@
     }
     .fs-error-action:hover {
       background: #dc2626;
+    }
+    .fs-error-action:focus-visible {
+      outline: 2px solid var(--fs-color-error, #ef4444);
+      outline-offset: 2px;
     }
     .fs-error-details {
       margin-top: var(--fs-spacing-md);
@@ -1896,6 +1951,12 @@
       transform: rotate(-90deg);
     }
 
+    .run-history-header .collapse-toggle:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
+
     .run-history-filter {
       display: flex;
       gap: var(--fs-spacing-xs);
@@ -1915,6 +1976,11 @@
 
     .run-history-filter .filter-btn:hover {
       border-color: var(--fs-color-accent);
+    }
+
+    .run-history-filter .filter-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent);
+      outline-offset: 2px;
     }
 
     .run-history-filter .filter-btn.active {
@@ -2032,6 +2098,11 @@
       color: var(--fs-color-accent);
     }
 
+    .run-history-item-actions button:focus-visible {
+      outline: 2px solid var(--fs-color-accent);
+      outline-offset: 2px;
+    }
+
     /* =========================================================================
      * Run Detail Modal
      * =========================================================================
@@ -2089,6 +2160,11 @@
       color: var(--fs-color-error);
     }
 
+    .run-detail-close:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+    }
+
     .run-detail-content h3 {
       margin: 0 0 var(--fs-spacing-lg) 0;
       font-size: 16px;
@@ -2140,6 +2216,11 @@
       background: var(--fs-color-accent-hover);
     }
 
+    .btn-primary:focus-visible {
+      outline: 2px solid var(--fs-color-accent);
+      outline-offset: 2px;
+    }
+
     .btn-primary:disabled {
       background: var(--fs-color-bg-subtle);
       color: var(--fs-color-text-muted);
@@ -2159,6 +2240,11 @@
       width: 16px;
       height: 16px;
       cursor: pointer;
+    }
+
+    .exemplar-toggle input[type="checkbox"]:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
 
     /* Status badges for run detail */
@@ -2219,6 +2305,11 @@
     .teaching-mode-toggle:hover {
       background: var(--fs-color-bg-subtle, #f3f4f6);
       border-color: var(--fs-color-accent, #3b82f6);
+    }
+
+    .teaching-mode-toggle:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
 
     .teaching-mode-toggle.active {
@@ -2643,6 +2734,11 @@
       border-color: var(--fs-color-accent, #3b82f6);
     }
 
+    .run-control-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+    }
+
     .run-control-btn:disabled {
       opacity: 0.5;
       cursor: not-allowed;
@@ -2909,6 +3005,11 @@
       border-color: var(--fs-color-accent, #3b82f6);
     }
 
+    .node-inspector__retry-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+    }
+
     /* Form */
     .node-inspector__form {
       flex: 1;
@@ -3141,6 +3242,11 @@
       background: var(--fs-color-accent-hover, #2563eb);
     }
 
+    .node-inspector__list-add-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+    }
+
     /* Checkbox */
     .node-inspector__checkbox-label {
       display: flex;
@@ -3206,6 +3312,11 @@
 
     .node-inspector__btn--secondary:hover:not(:disabled) {
       background: var(--fs-color-bg-subtle, #f3f4f6);
+    }
+
+    .node-inspector__btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
 
     .node-inspector__btn-spinner {
@@ -3304,6 +3415,11 @@
 
     .inventory-counts__expand-btn:hover {
       background: var(--fs-color-bg-subtle);
+    }
+
+    .inventory-counts__expand-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
 
     .inventory-counts__bar {
@@ -3577,6 +3693,11 @@
       background: var(--fs-color-accent-hover);
     }
 
+    .toast__action:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+    }
+
     .toast__close {
       flex-shrink: 0;
       width: 32px;
@@ -3595,6 +3716,11 @@
     .toast__close:hover {
       background: var(--fs-color-bg-subtle);
       color: var(--fs-color-text);
+    }
+
+    .toast__close:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: -2px;
     }
 
     @keyframes toast-slide-in {


### PR DESCRIPTION
🎨 Palette: Add keyboard focus visible states to all interactive elements\n\n💡 What: Added `:focus-visible` CSS states with a 2px accent-colored outline to dozens of interactive elements (buttons, toggles, modal closes, actions, etc.) across the Flow Studio UI.\n🎯 Why: Many custom interactive elements lacked visible focus indicators when navigating via keyboard, making the application inaccessible for non-mouse users.\n♿ Accessibility: Drastically improves keyboard navigation by providing a clear visual indicator of the currently focused element, conforming to WCAG focus visibility guidelines. Prioritized `:focus-visible` over `:focus` to ensure focus rings only appear for keyboard navigation, not mouse clicks.\n✅ Verification: No targeted automated tests exist for CSS focus states, so verification was limited to manual inspection, Playwright screenshots, and running frontend TypeScript checks.

---
*PR created automatically by Jules for task [9412838976031271989](https://jules.google.com/task/9412838976031271989) started by @EffortlessSteven*