### PR TITLE
🎨 Palette: Add focus-visible states to interactive toggles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-08 - Added Focus-Visible to Toggles
+**Learning:** Found a widespread pattern where custom toggles and selectors (like view-toggle, mode-toggle, and run-selectors) lacked proper keyboard `focus-visible` states, relying entirely on hover states. This hides the active element from keyboard-only users.
+**Action:** Adding consistent `focus-visible` standard styles globally using the accent color prevents these interactive elements from becoming inaccessible.

--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -3652,3 +3652,29 @@
       outline: none;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     }
+
+/* --- Palette: Focus Visible Enhancements --- */
+.run-history-filter .filter-btn:focus-visible,
+.teaching-mode-toggle:focus-visible,
+.run-history-header .collapse-toggle:focus-visible,
+.governance-toggle:focus-visible,
+.run-selector:focus-visible {
+  outline: 2px solid var(--fs-color-accent, #3b82f6);
+  outline-offset: 2px;
+}
+
+.mode-toggle button:focus-visible,
+.view-toggle button:focus-visible {
+  outline: 2px solid var(--fs-color-accent, #3b82f6);
+  outline-offset: -2px;
+}
+
+.run-control-btn:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.run-control-btn:focus-visible {
+  outline: 2px solid var(--fs-color-accent, #3b82f6);
+  outline-offset: 2px;
+  box-shadow: none;
+}

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -4289,6 +4289,32 @@
       outline: none;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     }
+
+/* --- Palette: Focus Visible Enhancements --- */
+.run-history-filter .filter-btn:focus-visible,
+.teaching-mode-toggle:focus-visible,
+.run-history-header .collapse-toggle:focus-visible,
+.governance-toggle:focus-visible,
+.run-selector:focus-visible {
+  outline: 2px solid var(--fs-color-accent, #3b82f6);
+  outline-offset: 2px;
+}
+
+.mode-toggle button:focus-visible,
+.view-toggle button:focus-visible {
+  outline: 2px solid var(--fs-color-accent, #3b82f6);
+  outline-offset: -2px;
+}
+
+.run-control-btn:focus:not(:focus-visible) {
+  box-shadow: none;
+}
+
+.run-control-btn:focus-visible {
+  outline: 2px solid var(--fs-color-accent, #3b82f6);
+  outline-offset: 2px;
+  box-shadow: none;
+}
   </style>
   <script type="application/json" data-inline-source="flowstudio-js-bundle">
 // api.js


### PR DESCRIPTION
🎨 Palette: Add focus-visible states to interactive toggles\n💡 What: Added consistent keyboard focus-visible styles to interactive UI elements (toggles, filters, controls).\n🎯 Why: Custom components lacked clear focus indicators, making keyboard navigation difficult.\n♿ Accessibility: Improves WCAG 2.1 Focus Visible compliance for keyboard users.

---
*PR created automatically by Jules for task [11030695139642735621](https://jules.google.com/task/11030695139642735621) started by @EffortlessSteven*