### PR TITLE
🎨 Palette: Improve keyboard accessibility focus styles

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-06-08 - Keyboard accessibility focus rings
+**Learning:** When adding focus styles to interactive UI elements to satisfy keyboard navigation a11y, using `:focus-visible` over `:focus` is strictly preferred. It ensures focus rings display for keyboard users while staying hidden during mouse clicks, preserving visual layout.
+**Action:** Always favor `:focus-visible` over `:focus` when styling `.btn` or similar interactive UI elements.

--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -1020,6 +1020,10 @@
     .view-toggle button:hover {
       background: #e5e7eb;
     }
+    .view-toggle button:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: -2px;
+    }
     .view-toggle button.active {
       background: #0f766e;
       color: white;
@@ -1253,6 +1257,10 @@
     .copy-btn:hover {
       background: #e5e7eb;
       border-color: #9ca3af;
+    }
+    .copy-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
     .copy-btn.copied {
       background: #d1fae5;
@@ -1896,6 +1904,12 @@
       transform: rotate(-90deg);
     }
 
+    .run-history-header .collapse-toggle:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
+
     .run-history-filter {
       display: flex;
       gap: var(--fs-spacing-xs);
@@ -1921,6 +1935,11 @@
       background: var(--fs-color-accent-bg);
       border-color: var(--fs-color-accent);
       color: var(--fs-color-accent);
+    }
+
+    .run-history-filter .filter-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 1px;
     }
 
     .run-history-list {
@@ -2648,7 +2667,7 @@
       cursor: not-allowed;
     }
 
-    .run-control-btn:focus {
+    .run-control-btn:focus-visible {
       outline: none;
       box-shadow: 0 0 0 2px var(--fs-color-accent-bg, #dbeafe);
     }


### PR DESCRIPTION
🎨 Palette: Improve keyboard accessibility focus styles

💡 What: Added `:focus-visible` states to `.view-toggle button`, `.copy-btn`, `.collapse-toggle`, `.filter-btn`, and updated `.run-control-btn` to use `:focus-visible` instead of `:focus`.
🎯 Why: Ensures keyboard navigation properly highlights focused elements, while maintaining a clean look for mouse users.
♿ Accessibility: Improves visual indication for keyboard users interacting with interactive controls without displaying focus rings upon mouse clicks.

---
*PR created automatically by Jules for task [8273282062811940386](https://jules.google.com/task/8273282062811940386) started by @EffortlessSteven*