### PR TITLE
🎨 Palette: [UX improvement] Add accessible focus-visible styles to custom UI buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-06-09 - Ensure generic buttons use focus-visible
+**Learning:** Custom UI buttons without native button styling or with custom backgrounds often lack visible focus indicators, heavily hurting keyboard accessibility. Specifically using `:focus-visible` instead of `:focus` prevents annoying outlines when clicking while preserving them for keyboard users.
+**Action:** Always verify keyboard navigation by tabbing through all custom interactive elements, and append `:focus-visible` with `outline` and `outline-offset` to the styling of custom buttons.

--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -2648,7 +2648,7 @@
       cursor: not-allowed;
     }
 
-    .run-control-btn:focus {
+    .run-control-btn:focus-visible {
       outline: none;
       box-shadow: 0 0 0 2px var(--fs-color-accent-bg, #dbeafe);
     }
@@ -3651,4 +3651,15 @@
       top: 0;
       outline: none;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+
+    /* Accessibility focus styles for custom buttons */
+    .filter-btn:focus-visible,
+    .view-toggle button:focus-visible,
+    .mode-toggle button:focus-visible,
+    .tour-dropdown-btn:focus-visible,
+    .copy-btn:focus-visible,
+    .collapse-toggle:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -3285,7 +3285,7 @@
       cursor: not-allowed;
     }
 
-    .run-control-btn:focus {
+    .run-control-btn:focus-visible {
       outline: none;
       box-shadow: 0 0 0 2px var(--fs-color-accent-bg, #dbeafe);
     }
@@ -4288,6 +4288,17 @@
       top: 0;
       outline: none;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+    }
+
+    /* Accessibility focus styles for custom buttons */
+    .filter-btn:focus-visible,
+    .view-toggle button:focus-visible,
+    .mode-toggle button:focus-visible,
+    .tour-dropdown-btn:focus-visible,
+    .copy-btn:focus-visible,
+    .collapse-toggle:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
   </style>
   <script type="application/json" data-inline-source="flowstudio-js-bundle">


### PR DESCRIPTION
💡 What: Replaced `:focus` with `:focus-visible` for run control buttons and added missing `:focus-visible` styles to other custom UI buttons (`.filter-btn`, `.view-toggle`, `.mode-toggle`, `.tour-dropdown-btn`, etc.).
🎯 Why: Many custom UI buttons lacked visual indicators when navigated via keyboard, making it difficult for keyboard-only users to know which element had focus. By using `:focus-visible` instead of `:focus`, we ensure keyboard users get a clear visual outline while mouse users do not get annoying outlines on click.
♿ Accessibility: Greatly improves keyboard navigation and meets basic focus visibility requirements.

---
*PR created automatically by Jules for task [11823762661658946148](https://jules.google.com/task/11823762661658946148) started by @EffortlessSteven*