### PR TITLE
🎨 Palette: Add focus-visible styles to secondary buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-10 - Focus-Visible Extensibility
+**Learning:** Many secondary buttons/toggles (.mode-toggle, .copy-btn, etc.) in custom control panels lack focus styles, leading to inaccessible keyboard navigation on complex dashboards.
+**Action:** Systematically audit all interactive custom elements (like segmented toggles or filter buttons) and apply standard `:focus-visible` outlines matching the design system's accent color.

--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -3652,3 +3652,15 @@
       outline: none;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     }
+
+/* Accessibility: Focus visible styles for secondary controls */
+.copy-btn:focus-visible,
+.mode-toggle button:focus-visible,
+.view-toggle button:focus-visible,
+.tour-dropdown-btn:focus-visible,
+.run-history-filter .filter-btn:focus-visible,
+.run-history-header .collapse-toggle:focus-visible,
+.run-selector:focus-visible {
+  outline: 2px solid var(--fs-color-accent, #3b82f6);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
🎨 Palette: Add focus-visible styles to secondary buttons

💡 What: Added `:focus-visible` accessibility outlines to various secondary controls including copy buttons, mode toggles, filter buttons, and run selectors.
🎯 Why: Improves keyboard navigation support, ensuring interactive elements have clear focus indicators for users relying on keyboard navigation or screen readers.
📸 Before/After: Focus states are now visible during keyboard navigation (Tab/Shift+Tab) and hidden for mouse clicks.
♿ Accessibility: Resolves missing focus states for keyboard users using standard design system accent colors.

---
*PR created automatically by Jules for task [15140003118588090203](https://jules.google.com/task/15140003118588090203) started by @EffortlessSteven*