### PR TITLE
⚡ Bolt: [performance improvement] Optimize SpecManager.list_runs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,10 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+## 2024-03-22 - Optimize SpecManager.list_runs using os.scandir
+**Learning:** `Path.iterdir()` can be surprisingly slow in directories with many items compared to `os.scandir()`.
+**Action:** Replace `iterdir()` with `os.scandir()` and lexicographical sort when sorting large lists of items to optimize performance.
+
+## 2024-03-22 - Leverage os.scandir cached stat attributes
+**Learning:** While `os.scandir()` yields names faster than `Path.iterdir()`, its real performance power comes from its `DirEntry` objects caching `stat()` calls. Calling `Path.is_dir()` inside the processing loop defeats this purpose by invoking redundant system `stat` calls.
+**Action:** When using `os.scandir()`, evaluate `.is_dir()` (or other stats) directly on the `DirEntry` object during the initial comprehension or loop, not later on constructed `Path` objects.

--- a/swarm/api/services/spec_manager.py
+++ b/swarm/api/services/spec_manager.py
@@ -20,6 +20,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple
@@ -503,9 +504,14 @@ class SpecManager:
         if not self.runs_root.exists():
             return runs
 
-        for run_dir in sorted(self.runs_root.iterdir(), reverse=True):
-            if not run_dir.is_dir():
-                continue
+        try:
+            with os.scandir(self.runs_root) as entries:
+                run_names = sorted([e.name for e in entries if e.is_dir()], reverse=True)
+        except OSError:
+            run_names = []
+
+        for name in run_names:
+            run_dir = self.runs_root / name
 
             state_file = run_dir / "run_state.json"
             if state_file.exists():


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Optimize SpecManager.list_runs

💡 What: Replaced `Path.iterdir()` with `os.scandir()` in `list_runs` to sort names instead of `Path` objects, and utilized the cached `.is_dir()` on the `DirEntry`.
🎯 Why: `iterdir()` constructs full `Path` objects and incurs a secondary `stat()` system call when checking `.is_dir()`, which can be slow in large run directories. `os.scandir` yields strings and caches the stat calls.
📊 Impact: Reduces filesystem iteration and stat call overhead for listing runs.
🔬 Measurement: Verify tests run fine and ensure run sorting continues to work correctly.

---
*PR created automatically by Jules for task [8463071762843651485](https://jules.google.com/task/8463071762843651485) started by @EffortlessSteven*