### PR TITLE
🎨 Palette: Add aria-expanded to Routing Decision Card toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-06-13 - Add aria-expanded to Routing Decision Card toggle
+**Learning:** Found a custom collapsible component in `RoutingDecisionCard.js` that was missing `aria-expanded` state communication. When building custom expandable sections, we must always bind the `isExpanded` component state to the `aria-expanded` DOM attribute, otherwise screen readers have no context that the button toggles content visibility.
+**Action:** Always include `aria-expanded` and `aria-controls` when implementing custom accordion/toggle patterns, and hide decorative arrows with `aria-hidden="true"`.

--- a/swarm/tools/flow_studio_ui/js/components/RoutingDecisionCard.js
+++ b/swarm/tools/flow_studio_ui/js/components/RoutingDecisionCard.js
@@ -283,13 +283,14 @@ export class RoutingDecisionCard {
             return "";
         const expandedClass = this.isExpanded ? "routing-card__rejected--expanded" : "";
         const arrowIcon = this.isExpanded ? "\u25bc" : "\u25b6";
+        const isExpandedStr = this.isExpanded ? "true" : "false";
         const candidateCards = candidates
             .map((c) => this.buildCandidateCard(c, false))
             .join("");
         return `
       <div class="routing-card__section routing-card__rejected ${expandedClass}">
-        <button class="routing-card__rejected-toggle" data-action="toggle-rejected">
-          <span class="routing-card__rejected-arrow">${arrowIcon}</span>
+        <button class="routing-card__rejected-toggle" data-action="toggle-rejected" aria-expanded="${isExpandedStr}">
+          <span class="routing-card__rejected-arrow" aria-hidden="true">${arrowIcon}</span>
           <span>Other Candidates (${candidates.length})</span>
         </button>
         <div class="routing-card__rejected-content">


### PR DESCRIPTION
🎨 Palette: Add aria-expanded to Routing Decision Card toggle\n\n💡 What: Added `aria-expanded` state communication to the "Other Candidates" toggle button in `RoutingDecisionCard.js`, and `aria-hidden="true"` to the decorative arrow icon.\n🎯 Why: Screen readers had no context that this custom collapsible component was an expandable section, making it difficult for keyboard/assistive-tech users to know the state of the content.\n📸 Before/After: Before, `<button class="routing-card__rejected-toggle">`. After, `<button class="routing-card__rejected-toggle" aria-expanded="true/false">` with `aria-hidden` arrow.\n♿ Accessibility: Improved screen reader communication for expandable sections by strictly binding the component's internal `isExpanded` state to the DOM's `aria-expanded` attribute.

---
*PR created automatically by Jules for task [18245363025050270861](https://jules.google.com/task/18245363025050270861) started by @EffortlessSteven*