### PR TITLE
🎨 Palette: Add aria-label to icon-only buttons

### DIFF
--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" aria-label="Toggle expand" title="Toggle expand">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>

--- a/swarm/tools/flow_studio_ui/js/components/ForensicVerdictCard.js
+++ b/swarm/tools/flow_studio_ui/js/components/ForensicVerdictCard.js
@@ -340,6 +340,7 @@ export class ForensicVerdictCard {
         const expandBtn = document.createElement("button");
         expandBtn.className = "forensic-verdict-card__expand-btn";
         expandBtn.setAttribute("aria-expanded", String(this.isExpanded));
+        expandBtn.setAttribute("aria-label", this.isExpanded ? "Collapse section" : "Expand section");
         expandBtn.innerHTML = this.isExpanded ? "\u25B2" : "\u25BC";
         expandBtn.title = this.isExpanded ? "Collapse" : "Expand";
         expandBtn.addEventListener("click", () => {

--- a/swarm/tools/flow_studio_ui/js/selftest_ui.js
+++ b/swarm/tools/flow_studio_ui/js/selftest_ui.js
@@ -234,7 +234,7 @@ export function renderSelftestStepModal(step) {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" aria-label="Copy command" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/js/ui_fragments.js
+++ b/swarm/tools/flow_studio_ui/js/ui_fragments.js
@@ -21,7 +21,7 @@ export function renderNoRuns() {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" aria-label="Copy command" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;

--- a/swarm/tools/flow_studio_ui/js/utils.js
+++ b/swarm/tools/flow_studio_ui/js/utils.js
@@ -76,6 +76,7 @@ export function createCopyButton(text, label = "Copy") {
     btn.className = "copy-btn";
     btn.textContent = label;
     btn.title = "Copy to clipboard";
+    btn.setAttribute("aria-label", "Copy to clipboard");
     btn.addEventListener("click", () => {
         void copyToClipboard(text);
         btn.textContent = "Copied!";

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" aria-label="Toggle expand" title="Toggle expand">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>

--- a/swarm/tools/flow_studio_ui/src/components/ForensicVerdictCard.ts
+++ b/swarm/tools/flow_studio_ui/src/components/ForensicVerdictCard.ts
@@ -453,6 +453,7 @@ export class ForensicVerdictCard {
     const expandBtn = document.createElement("button");
     expandBtn.className = "forensic-verdict-card__expand-btn";
     expandBtn.setAttribute("aria-expanded", String(this.isExpanded));
+    expandBtn.setAttribute("aria-label", this.isExpanded ? "Collapse section" : "Expand section");
     expandBtn.innerHTML = this.isExpanded ? "\u25B2" : "\u25BC";
     expandBtn.title = this.isExpanded ? "Collapse" : "Expand";
     expandBtn.addEventListener("click", () => {

--- a/swarm/tools/flow_studio_ui/src/selftest_ui.ts
+++ b/swarm/tools/flow_studio_ui/src/selftest_ui.ts
@@ -257,7 +257,7 @@ export function renderSelftestStepModal(step: SelftestStep): void {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" aria-label="Copy command" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/src/ui_fragments.ts
+++ b/swarm/tools/flow_studio_ui/src/ui_fragments.ts
@@ -24,7 +24,7 @@ export function renderNoRuns(): string {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" aria-label="Copy command" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;

--- a/swarm/tools/flow_studio_ui/src/utils.ts
+++ b/swarm/tools/flow_studio_ui/src/utils.ts
@@ -81,6 +81,7 @@ export function createCopyButton(text: string, label = "Copy"): HTMLButtonElemen
   btn.className = "copy-btn";
   btn.textContent = label;
   btn.title = "Copy to clipboard";
+  btn.setAttribute("aria-label", "Copy to clipboard");
   btn.addEventListener("click", () => {
     void copyToClipboard(text);
     btn.textContent = "Copied!";


### PR DESCRIPTION
🎨 Palette: Add aria-label to icon-only buttons

💡 What: Added missing `aria-label` attributes to multiple icon-only buttons across the UI (e.g., copy buttons, expand/collapse toggles).
🎯 Why: Icon-only buttons without accessible names cannot be understood by screen reader users.
📸 Before/After: Buttons now announce their intent via `aria-label` instead of just a visual icon.
♿ Accessibility: Improves WCAG 4.1.2 Name, Role, Value compliance by ensuring all interactive elements have accessible names.

---
*PR created automatically by Jules for task [16057750563861523926](https://jules.google.com/task/16057750563861523926) started by @EffortlessSteven*