### PR TITLE
🎨 Palette: Add ARIA attributes to boundary review toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-15 - Added missing ARIA attributes to Flow Studio Boundary Review Toggle
+**Learning:** Implementing expand/collapse toggles requires `aria-expanded` coupled with `aria-controls` pointing to the ID of the expanded section. Missing these is a common oversight that impacts screen reader users.
+**Action:** Always ensure expand/collapse toggles correctly implement `aria-expanded`, `aria-controls`, and have an explicit `id` on their target container.

--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-controls="boundary-sections" aria-label="Toggle boundary review sections">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -244,7 +244,7 @@ export function renderBoundaryReviewPanel(data) {
       ${renderSummaryBar(data)}
       ${renderUncertaintyNotes(data.uncertainty_notes)}
 
-      <div class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
+      <div id="boundary-sections" class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
         ${renderSection("Assumptions", assumptionCards, assumptionCards.length > 5)}
         ${renderSection("Decisions", decisionCards, decisionCards.length > 5)}
         ${renderSection("Detours", detourCards)}
@@ -309,6 +309,7 @@ export function setupBoundaryReviewHandlers(container) {
                 sections.classList.toggle("collapsed", !isExpanded);
             }
             target.textContent = isExpanded ? "▼" : "▶";
+            target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
         }
     });
 }

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded ? 'true' : 'false'}" aria-controls="boundary-sections" aria-label="Toggle boundary review sections">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -273,7 +273,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       ${renderSummaryBar(data)}
       ${renderUncertaintyNotes(data.uncertainty_notes)}
 
-      <div class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
+      <div id="boundary-sections" class="boundary-sections ${isExpanded ? "expanded" : "collapsed"}">
         ${renderSection("Assumptions", assumptionCards, assumptionCards.length > 5)}
         ${renderSection("Decisions", decisionCards, decisionCards.length > 5)}
         ${renderSection("Detours", detourCards)}
@@ -345,6 +345,7 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", isExpanded ? "true" : "false");
     }
   });
 }


### PR DESCRIPTION
💡 What: Added missing `aria-expanded`, `aria-controls`, and `aria-label` attributes to the boundary review panel's expand/collapse button, along with dynamically updating the `aria-expanded` state during interaction. Also added the `boundary-sections` ID to the target container.
🎯 Why: To improve screen reader accessibility by providing appropriate context and state tracking for the expand/collapse interaction within the Flow Studio boundary review modal.
📸 Before/After: N/A - Visuals are unaffected.
♿ Accessibility: Ensures that screen reader users are aware of the toggle button, its current expanded/collapsed state, and the specific section it controls.

---
*PR created automatically by Jules for task [6655524061862245702](https://jules.google.com/task/6655524061862245702) started by @EffortlessSteven*