### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-label="Toggle expand">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>

--- a/swarm/tools/flow_studio_ui/src/selftest_ui.ts
+++ b/swarm/tools/flow_studio_ui/src/selftest_ui.ts
@@ -257,7 +257,7 @@ export function renderSelftestStepModal(step: SelftestStep): void {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard(\'${escapeHtml(cmd).replace(/\'/g, "\\\'")}\')" title="Copy" aria-label="Copy command">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/src/ui_fragments.ts
+++ b/swarm/tools/flow_studio_ui/src/ui_fragments.ts
@@ -24,7 +24,7 @@ export function renderNoRuns(): string {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;


### PR DESCRIPTION
💡 What: Added missing aria-label attributes to icon-only copy and toggle buttons in the Flow Studio UI.
🎯 Why: Screen reader users need descriptive text for buttons that only contain icons or emojis to understand their function.
📸 Before/After: N/A - Visually identical, purely an accessibility improvement in the DOM.
♿ Accessibility: Screen readers will now announce "Toggle expand" or "Copy command" instead of just "button" or reading the emoji character.

---
*PR created automatically by Jules for task [3089418931591727879](https://jules.google.com/task/3089418931591727879) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DOM-only accessibility attributes and a minor string-escaping tweak in generated HTML; no behavior, auth, or data-path changes.
> 
> **Overview**
> Adds **`aria-label`** to icon-only controls in Flow Studio so assistive tech gets a clear name instead of a generic “button” or the emoji glyph.
> 
> The **Boundary Review** expand/collapse control gets `aria-label="Toggle expand"`. **Copy** actions in the empty “no runs” state (`make demo-run`) and in the **selftest step** command list get `aria-label="Copy command"` (alongside existing `title`). In `selftest_ui.ts`, the copy button’s inline `onclick` string also uses adjusted quote escaping so the generated HTML stays valid.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a70dcc14506332166066a58b21b1729ca57b04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->