### PR TITLE
⚡ Bolt: Replace Path.iterdir() with os.scandir() for performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+## 2026-06-16 - Use os.scandir over Path.iterdir
+**Learning:** Path.iterdir() incurs unnecessary overhead from instantiating Path objects and stat() calls, whereas os.scandir() is significantly faster for directory traversal by yielding DirEntry objects with cached attributes.
+**Action:** Opt for os.scandir() wrapped in a context manager when iterating through large directories to avoid performance bottlenecks.

--- a/swarm/runtime/statsdb/rebuild.py
+++ b/swarm/runtime/statsdb/rebuild.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -129,9 +130,9 @@ class StatsDBRebuildMixin:
                 logger.warning("Runs directory does not exist: %s", runs_dir)
                 return stats
 
-            run_ids = [
-                d.name for d in runs_dir.iterdir() if d.is_dir() and not d.name.startswith(".")
-            ]
+            # Performance: Use os.scandir() instead of Path.iterdir() to avoid Path object instantiation overhead
+            with os.scandir(runs_dir) as entries:
+                run_ids = [d.name for d in entries if d.is_dir() and not d.name.startswith(".")]
 
         logger.info("Rebuilding projections for %d runs", len(run_ids))
 
@@ -236,7 +237,9 @@ def rebuild_stats_db(
             logger.warning("Runs directory does not exist: %s", runs_dir)
             return stats
 
-        run_ids = [d.name for d in runs_dir.iterdir() if d.is_dir() and not d.name.startswith(".")]
+        # Performance: Use os.scandir() instead of Path.iterdir() to avoid Path object instantiation overhead
+        with os.scandir(runs_dir) as entries:
+            run_ids = [d.name for d in entries if d.is_dir() and not d.name.startswith(".")]
 
     logger.info("Rebuilding stats DB from %d runs", len(run_ids))
 
@@ -278,43 +281,45 @@ def rebuild_stats_db(
             # Set ingestion context to allow record_* calls (projection-only mode)
             _ingestion_context.active = True
             try:
-                for flow_dir in run_path.iterdir():
-                    if not flow_dir.is_dir() or flow_dir.name.startswith("."):
-                        continue
+                # Performance: Use os.scandir() instead of Path.iterdir() to avoid Path object instantiation overhead
+                with os.scandir(run_path) as entries:
+                    for flow_dir_entry in entries:
+                        if not flow_dir_entry.is_dir() or flow_dir_entry.name.startswith("."):
+                            continue
 
-                    handoff_dir = flow_dir / "handoff"
-                    if not handoff_dir.exists():
-                        continue
+                        handoff_dir = run_path / flow_dir_entry.name / "handoff"
+                        if not handoff_dir.exists():
+                            continue
 
-                    for envelope_file in handoff_dir.glob("*.json"):
-                        try:
-                            with envelope_file.open("r", encoding="utf-8") as f:
-                                envelope_data = json.load(f)
+                        for envelope_file in handoff_dir.glob("*.json"):
+                            try:
+                                with envelope_file.open("r", encoding="utf-8") as f:
+                                    envelope_data = json.load(f)
 
-                            # Record file changes from envelope if present
-                            file_changes = envelope_data.get("file_changes", {})
-                            if file_changes and "files" in file_changes:
-                                step_id = envelope_data.get("step_id", envelope_file.stem)
-                                for fc in file_changes.get("files", []):
-                                    db.record_file_change(
-                                        run_id=run_id,
-                                        step_id=step_id,
-                                        file_path=fc.get("path", ""),
-                                        change_type=fc.get("status", "modified"),
-                                        lines_added=fc.get("insertions", 0),
-                                        lines_removed=fc.get("deletions", 0),
-                                    )
+                                # Record file changes from envelope if present
+                                file_changes = envelope_data.get("file_changes", {})
+                                if file_changes and "files" in file_changes:
+                                    step_id = envelope_data.get("step_id", envelope_file.stem)
+                                    for fc in file_changes.get("files", []):
+                                        db.record_file_change(
+                                            run_id=run_id,
+                                            step_id=step_id,
+                                            file_path=fc.get("path", ""),
+                                            change_type=fc.get("status", "modified"),
+                                            lines_added=fc.get("insertions", 0),
+                                            lines_removed=fc.get("deletions", 0),
+                                        )
 
-                            stats["envelopes_processed"] += 1
+                                stats["envelopes_processed"] += 1
 
-                        except (json.JSONDecodeError, IOError) as e:
-                            stats["errors"].append(
-                                {
-                                    "run_id": run_id,
-                                    "file": str(envelope_file),
-                                    "error": str(e),
-                                }
-                            )
+                            except (json.JSONDecodeError, IOError) as e:
+                                stats["errors"].append(
+                                    {
+                                        "run_id": run_id,
+                                        "file": str(envelope_file),
+                                        "error": str(e),
+                                    }
+                                )
             finally:
                 _ingestion_context.active = False
 


### PR DESCRIPTION
⚡ Bolt: Replace Path.iterdir() with os.scandir() for performance

💡 What: Refactored `rebuild_all_from_events` and `rebuild_stats_db` in `swarm/runtime/statsdb/rebuild.py` to utilize `os.scandir()` instead of `Path.iterdir()`.
🎯 Why: `Path.iterdir()` instantiates `Path` objects and inherently suffers from performance overhead. `os.scandir()` yields `DirEntry` objects with cached `stat` metadata, significantly improving directory traversal speed, which is a known bottleneck when scaling up runs.
📊 Impact: Expected to reduce directory iteration time on large lists of run directories (e.g. >50,000 directories) and eliminate `iterdir` overhead bottlenecks.
🔬 Measurement: Verified the code behaves equivalently by passing targeted unit tests on `test_db_projection.py`, `test_resilient_db.py`, and `test_state_builder.py`.

---
*PR created automatically by Jules for task [7679921483359519389](https://jules.google.com/task/7679921483359519389) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving performance refactor in offline rebuild/projection code; no auth, API, or data-model changes.
> 
> **Overview**
> Speeds up **stats DB rebuild** when there are many run directories by swapping **`Path.iterdir()`** for **`os.scandir()`** (context-managed) in `swarm/runtime/statsdb/rebuild.py`.
> 
> The same traversal pattern is used in three spots: discovering run IDs in **`rebuild_all_from_events`** and **`rebuild_stats_db`**, and walking per-run flow subdirectories when ingesting handoff envelope JSON for file-change projection. Filtering (directories only, skip dot-prefixed names) and downstream logic are unchanged.
> 
> Documents the **`os.scandir` vs `Path.iterdir`** guidance in **`.jules/bolt.md`** for future large-directory work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bddeeeee996f0d9a865eb2991f9c0852cdef337b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->