### PR TITLE
🎨 Palette: Improve accessibility of copy buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-16 - Adding accessibility to utility buttons
+**Learning:** Utility buttons like 'Copy' need explicit `aria-label` attributes and keyboard focus indicators (`focus-visible`), especially when used across multiple views.
+**Action:** Audit all utility buttons for accessible labels and focus states during creation.

--- a/swarm/tools/flow_studio_ui/css/flow-studio.base.css
+++ b/swarm/tools/flow_studio_ui/css/flow-studio.base.css
@@ -1254,6 +1254,10 @@
       background: #e5e7eb;
       border-color: #9ca3af;
     }
+    .copy-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
+    }
     .copy-btn.copied {
       background: #d1fae5;
       border-color: #10b981;

--- a/swarm/tools/flow_studio_ui/fragments/10-header.html
+++ b/swarm/tools/flow_studio_ui/fragments/10-header.html
@@ -40,7 +40,7 @@
       </button>
       <div class="muted author-only" style="display: flex; align-items: center; gap: 8px;" data-uiid="flow_studio.header.reload">
         <span class="mono">make dev-check</span>
-        <button id="copy-dev-check-btn" class="copy-btn" title="Copy command to clipboard" data-uiid="flow_studio.header.reload.copy_btn">Copy</button>
+        <button id="copy-dev-check-btn" class="copy-btn" title="Copy command to clipboard" aria-label="Copy make dev-check command" data-uiid="flow_studio.header.reload.copy_btn">Copy</button>
         <button id="reload-btn" class="fs-button-small" data-uiid="flow_studio.header.reload.btn">Reload</button>
       </div>
       <button id="help-btn" class="fs-icon-button" title="Flow Studio help" aria-label="Show keyboard shortcuts" data-uiid="flow_studio.header.help">?</button>

--- a/swarm/tools/flow_studio_ui/fragments/50-inspector.html
+++ b/swarm/tools/flow_studio_ui/fragments/50-inspector.html
@@ -22,11 +22,11 @@
         </div>
         <div class="command-line">
            <span class="command-text">uv run swarm/tools/gen_flows.py</span>
-           <button class="copy-btn" onclick="navigator.clipboard.writeText('uv run swarm/tools/gen_flows.py').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard">Copy</button>
+           <button class="copy-btn" onclick="navigator.clipboard.writeText('uv run swarm/tools/gen_flows.py').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard" aria-label="Copy uv run swarm/tools/gen_flows.py command">Copy</button>
         </div>
         <div class="command-line">
            <span class="command-text">make validate-swarm</span>
-           <button class="copy-btn" onclick="navigator.clipboard.writeText('make validate-swarm').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard">Copy</button>
+           <button class="copy-btn" onclick="navigator.clipboard.writeText('make validate-swarm').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard" aria-label="Copy make validate-swarm command">Copy</button>
         </div>
       </div>
       <p style="margin-top: 12px; font-size: 12px; color: #6b7280;">

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -58,7 +58,7 @@
       </button>
       <div class="muted author-only" style="display: flex; align-items: center; gap: 8px;" data-uiid="flow_studio.header.reload">
         <span class="mono">make dev-check</span>
-        <button id="copy-dev-check-btn" class="copy-btn" title="Copy command to clipboard" data-uiid="flow_studio.header.reload.copy_btn">Copy</button>
+        <button id="copy-dev-check-btn" class="copy-btn" title="Copy command to clipboard" aria-label="Copy make dev-check command" data-uiid="flow_studio.header.reload.copy_btn">Copy</button>
         <button id="reload-btn" class="fs-button-small" data-uiid="flow_studio.header.reload.btn">Reload</button>
       </div>
       <button id="help-btn" class="fs-icon-button" title="Flow Studio help" aria-label="Show keyboard shortcuts" data-uiid="flow_studio.header.help">?</button>
@@ -214,11 +214,11 @@
         </div>
         <div class="command-line">
            <span class="command-text">uv run swarm/tools/gen_flows.py</span>
-           <button class="copy-btn" onclick="navigator.clipboard.writeText('uv run swarm/tools/gen_flows.py').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard">Copy</button>
+           <button class="copy-btn" onclick="navigator.clipboard.writeText('uv run swarm/tools/gen_flows.py').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard" aria-label="Copy uv run swarm/tools/gen_flows.py command">Copy</button>
         </div>
         <div class="command-line">
            <span class="command-text">make validate-swarm</span>
-           <button class="copy-btn" onclick="navigator.clipboard.writeText('make validate-swarm').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard">Copy</button>
+           <button class="copy-btn" onclick="navigator.clipboard.writeText('make validate-swarm').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard" aria-label="Copy make validate-swarm command">Copy</button>
         </div>
       </div>
       <p style="margin-top: 12px; font-size: 12px; color: #6b7280;">
@@ -1890,6 +1890,10 @@
     .copy-btn:hover {
       background: #e5e7eb;
       border-color: #9ca3af;
+    }
+    .copy-btn:focus-visible {
+      outline: 2px solid var(--fs-color-accent, #3b82f6);
+      outline-offset: 2px;
     }
     .copy-btn.copied {
       background: #d1fae5;


### PR DESCRIPTION
💡 What: Added `aria-label` to 'Copy' buttons and standard `focus-visible` states.
🎯 Why: Makes utility actions identifiable to screen readers and navigable via keyboard.
📸 Before/After: Visual outline when focused by keyboard, descriptive screen reader text.
♿ Accessibility: Ensures generic buttons have descriptive labels and visual focus indicators.

---
*PR created automatically by Jules for task [14928771099097635006](https://jules.google.com/task/14928771099097635006) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup and CSS-only accessibility tweaks with no behavior or API changes.
> 
> **Overview**
> Improves **keyboard and screen-reader access** for Flow Studio’s generic “Copy” utility buttons by giving each one a **command-specific `aria-label`** (e.g. `make dev-check`, `uv run swarm/tools/gen_flows.py`, `make validate-swarm`) in the header fragment, inspector quick-commands, and the bundled `index.html`.
> 
> Adds a **`.copy-btn:focus-visible`** style (accent outline, aligned with other Flow Studio controls) in `flow-studio.base.css` and the inline styles in `index.html`. Documents the pattern in **`.jules/palette.md`** for future utility-button work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1046686bd659a61739bdc6ad66669c2fead0f0ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->