### PR TITLE
🎨 Palette: Add ARIA attributes to expandable sections

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-17 - Add ARIA attributes to expandable sections
+**Learning:** Expandable sections using simple icon toggles (▼/▶) need both `aria-expanded` to communicate state and `aria-label` to communicate purpose to screen reader users.
+**Action:** Always include `aria-expanded` dynamically tied to the component's state and a descriptive `aria-label` for custom toggle buttons.

--- a/swarm/tools/flow_studio_ui/index.html
+++ b/swarm/tools/flow_studio_ui/index.html
@@ -12812,7 +12812,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded}" aria-label="Toggle boundary review">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>

--- a/swarm/tools/flow_studio_ui/js/boundary_review.js
+++ b/swarm/tools/flow_studio_ui/js/boundary_review.js
@@ -236,7 +236,7 @@ export function renderBoundaryReviewPanel(data) {
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded}" aria-label="Toggle boundary review">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-expanded="${isExpanded}" aria-label="Toggle boundary review">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>


### PR DESCRIPTION
💡 What: Added `aria-expanded` and `aria-label` to the toggle boundary review icon-only button.\n🎯 Why: Icon-only expand buttons (▼/▶) lack context for screen reader users and don't communicate their toggled state correctly.\n📸 Before/After: N/A\n♿ Accessibility: Improves screen reader accessibility by clearly associating the button's toggle action and state.

---
*PR created automatically by Jules for task [5223204847943448836](https://jules.google.com/task/5223204847943448836) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup-only accessibility attributes on a UI toggle; no logic or API changes.
> 
> **Overview**
> Adds **`aria-expanded`** (bound to `isExpanded`) and **`aria-label="Toggle boundary review"`** on the Boundary Review panel’s icon-only **▼/▶** expand button in `boundary_review` markup, mirrored in the TypeScript source, compiled JS, and bundled `index.html`.
> 
> Documents the pattern in **`.jules/palette.md`** so future icon toggles include state and an accessible name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072cec8bfe115eaa335f85b5ed56b4392bda977a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->