### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XXE Vulnerability in XML Parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-01-23 - Prevent XML vulnerabilities with defusedxml
+**Vulnerability:** XML External Entity (XXE) and billion laughs vulnerabilities via `xml.etree.ElementTree`.
+**Learning:** `xml.etree.ElementTree` is vulnerable to maliciously constructed XML data.
+**Prevention:** Always use `defusedxml.ElementTree` instead of `xml.etree.ElementTree` to prevent XML-based attacks.

--- a/docs/ADOPTING_SELFTEST_CORE.md
+++ b/docs/ADOPTING_SELFTEST_CORE.md
@@ -1254,7 +1254,7 @@ Create custom output formats:
 
 ```python
 from selftest_core.reporter import ReportGenerator
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 class JUnitReporter:
     """Generate JUnit XML reports for CI systems."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Security updates for medium-priority vulnerabilities
     "starlette>=0.46.0,<1.0.0",
     "urllib3>=2.3.0,<3.0.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/swarm/runtime/test_parser.py
+++ b/swarm/runtime/test_parser.py
@@ -35,11 +35,12 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+import defusedxml.ElementTree as ET
 
 from swarm.runtime.forensic_types import (
     FailureType,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -358,6 +368,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5,<2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0" },
     { name = "claude-agent-sdk", marker = "extra == 'dev'", specifier = ">=0.1.19" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix XXE Vulnerability in XML Parser

🚨 Severity: CRITICAL
💡 Vulnerability: The application was using standard xml.etree.ElementTree for parsing XML files, which is vulnerable to XML External Entity (XXE) injection and Billion Laughs expansion attacks.
🎯 Impact: An attacker could supply maliciously crafted test result XML (like JUnit output) and potentially read local files, execute server-side request forgery (SSRF), or cause denial of service via memory exhaustion.
🔧 Fix: Replaced xml.etree.ElementTree with defusedxml.ElementTree across the codebase and in documentation to safely process XML data. Added defusedxml to dependencies.
✅ Verification: All existing tests, schema validation, and yaml tests pass successfully after the integration of defusedxml.

---
*PR created automatically by Jules for task [9776463817890995824](https://jules.google.com/task/9776463817890995824) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Drop-in parser swap with a small new dependency; behavior for legitimate JUnit XML should stay the same while malicious XML is rejected more safely.
> 
> **Overview**
> Mitigates **XXE** and **billion laughs** risks when parsing untrusted JUnit/test XML by switching from `xml.etree.ElementTree` to **`defusedxml.ElementTree`**.
> 
> **`swarm/runtime/test_parser.py`** (`parse_junit_xml`) and the **custom JUnit reporter** example in **`docs/ADOPTING_SELFTEST_CORE.md`** now import `defusedxml`. **`defusedxml>=0.7.1`** is added to **`pyproject.toml`** and **`uv.lock`**. **`.jules/sentinel.md`** records the prevention rule for future changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72057e879b10b654f5c01441861497b2cd1720e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->