### PR TITLE
🎨 Palette: Add aria-labels to copy buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Improve accessibility of interactive elements
+**Learning:** Some interactive buttons like "Copy" in the inspector or code blocks do not have `aria-label`s, which can make it hard for screen reader users to identify their purpose out of context. The same applies to various close buttons in modals.
+**Action:** Add clear `aria-label`s to all icon-only or generic-text interactive elements, particularly "Copy" buttons.

--- a/swarm/tools/flow_studio_ui/fragments/10-header.html
+++ b/swarm/tools/flow_studio_ui/fragments/10-header.html
@@ -40,7 +40,7 @@
       </button>
       <div class="muted author-only" style="display: flex; align-items: center; gap: 8px;" data-uiid="flow_studio.header.reload">
         <span class="mono">make dev-check</span>
-        <button id="copy-dev-check-btn" class="copy-btn" title="Copy command to clipboard" data-uiid="flow_studio.header.reload.copy_btn">Copy</button>
+        <button id="copy-dev-check-btn" class="copy-btn" title="Copy command to clipboard" aria-label="Copy command" data-uiid="flow_studio.header.reload.copy_btn">Copy</button>
         <button id="reload-btn" class="fs-button-small" data-uiid="flow_studio.header.reload.btn">Reload</button>
       </div>
       <button id="help-btn" class="fs-icon-button" title="Flow Studio help" aria-label="Show keyboard shortcuts" data-uiid="flow_studio.header.help">?</button>

--- a/swarm/tools/flow_studio_ui/fragments/50-inspector.html
+++ b/swarm/tools/flow_studio_ui/fragments/50-inspector.html
@@ -22,11 +22,11 @@
         </div>
         <div class="command-line">
            <span class="command-text">uv run swarm/tools/gen_flows.py</span>
-           <button class="copy-btn" onclick="navigator.clipboard.writeText('uv run swarm/tools/gen_flows.py').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard">Copy</button>
+           <button class="copy-btn" onclick="navigator.clipboard.writeText('uv run swarm/tools/gen_flows.py').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard" aria-label="Copy command">Copy</button>
         </div>
         <div class="command-line">
            <span class="command-text">make validate-swarm</span>
-           <button class="copy-btn" onclick="navigator.clipboard.writeText('make validate-swarm').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard">Copy</button>
+           <button class="copy-btn" onclick="navigator.clipboard.writeText('make validate-swarm').then(() => { this.textContent = 'Copied!'; this.classList.add('copied'); setTimeout(() => { this.textContent = 'Copy'; this.classList.remove('copied'); }, 1500); })" title="Copy to clipboard" aria-label="Copy command">Copy</button>
         </div>
       </div>
       <p style="margin-top: 12px; font-size: 12px; color: #6b7280;">

--- a/swarm/tools/flow_studio_ui/js/selftest_ui.js
+++ b/swarm/tools/flow_studio_ui/js/selftest_ui.js
@@ -234,7 +234,7 @@ export function renderSelftestStepModal(step) {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy" aria-label="Copy command">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/js/ui_fragments.js
+++ b/swarm/tools/flow_studio_ui/js/ui_fragments.js
@@ -21,7 +21,7 @@ export function renderNoRuns() {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;

--- a/swarm/tools/flow_studio_ui/src/selftest_ui.ts
+++ b/swarm/tools/flow_studio_ui/src/selftest_ui.ts
@@ -257,7 +257,7 @@ export function renderSelftestStepModal(step: SelftestStep): void {
       ${commands.map(cmd => `
         <div class="selftest-command">
           <span class="fs-text-xs" style="flex: 1;">${escapeHtml(cmd)}</span>
-          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy">\ud83d\udccb</button>
+          <button class="selftest-command-copy-btn" onclick="window.copyToClipboard && window.copyToClipboard('${escapeHtml(cmd).replace(/'/g, "\\'")}')" title="Copy" aria-label="Copy command">\ud83d\udccb</button>
         </div>
       `).join("")}
     </div>

--- a/swarm/tools/flow_studio_ui/src/ui_fragments.ts
+++ b/swarm/tools/flow_studio_ui/src/ui_fragments.ts
@@ -24,7 +24,7 @@ export function renderNoRuns(): string {
       <p class="fs-empty-description">Generate example data to explore Flow Studio.</p>
       <div class="fs-copy-command">
         <code class="mono fs-empty-command">make demo-run</code>
-        <button class="fs-icon-button copy-button" title="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
+        <button class="fs-icon-button copy-button" title="Copy command" aria-label="Copy command" onclick="navigator.clipboard.writeText('make demo-run'); this.textContent='\u2713'; setTimeout(() => this.textContent='\uD83D\uDCCB', 2000)">\uD83D\uDCCB</button>
       </div>
     </div>
   `;


### PR DESCRIPTION
🎨 Palette: Add aria-labels to copy buttons

💡 What: Add aria-labels to icon-only Copy buttons in the UI to ensure they are accessible.

🎯 Why: Screen reader users cannot identify the purpose of icon-only or generic-text buttons out of context. Adding explicit aria-labels makes these elements identifiable and improves the overall accessibility of the application.

📸 Before/After: Not applicable (invisible change).

♿ Accessibility: Added aria-label='Copy command' to copy buttons across different views.

---
*PR created automatically by Jules for task [9279279716172713599](https://jules.google.com/task/9279279716172713599) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markup-only accessibility attributes with no logic or styling changes; behavior for sighted users is unchanged.
> 
> **Overview**
> Adds **`aria-label="Copy command"`** to Flow Studio copy controls so screen readers can name them when visible text is generic (“Copy”) or icon-only (clipboard emoji).
> 
> **Header & inspector:** The `make dev-check` copy control in `10-header.html` and the `gen_flows` / `validate-swarm` copy buttons in `50-inspector.html` now expose an explicit accessible name in addition to existing `title` tooltips.
> 
> **Dynamic UI:** The same label is applied in `ui_fragments` (no-runs `make demo-run` icon button) and `selftest_ui` (per-command clipboard buttons in the selftest step modal), with matching updates in both `.ts` sources and compiled `.js`.
> 
> **Docs:** `.jules/palette.md` records the accessibility learning and follow-up to label icon-only interactives (including modal close buttons, not changed in this PR).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de9ba12c0bf2997508f08e37f1285cc173697647. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->