### PR TITLE
🛡️ Sentinel: [HIGH] Fix XXE Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-18 - Prevent XXE vulnerabilities with defusedxml
+**Vulnerability:** Use of standard xml.etree.ElementTree is vulnerable to XML External Entity (XXE) attacks.
+**Learning:** Python's standard XML parsing libraries are vulnerable to malicious XML payloads by default.
+**Prevention:** Always use defusedxml.ElementTree instead of the standard xml.etree.ElementTree when parsing XML.

--- a/docs/ADOPTING_SELFTEST_CORE.md
+++ b/docs/ADOPTING_SELFTEST_CORE.md
@@ -1254,7 +1254,7 @@ Create custom output formats:
 
 ```python
 from selftest_core.reporter import ReportGenerator
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 class JUnitReporter:
     """Generate JUnit XML reports for CI systems."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Security updates for medium-priority vulnerabilities
     "starlette>=0.46.0,<1.0.0",
     "urllib3>=2.3.0,<3.0.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/swarm/runtime/test_parser.py
+++ b/swarm/runtime/test_parser.py
@@ -35,11 +35,12 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+import defusedxml.ElementTree as ET
 
 from swarm.runtime.forensic_types import (
     FailureType,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -358,6 +368,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5,<2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0" },
     { name = "claude-agent-sdk", marker = "extra == 'dev'", specifier = ">=0.1.19" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XXE Vulnerability

🚨 Severity: HIGH
💡 Vulnerability: Use of standard `xml.etree.ElementTree` parsing is vulnerable to XML External Entity (XXE) injection attacks.
🎯 Impact: An attacker could craft a malicious XML file (e.g., JUnit XML report) that, when parsed, could read local files on the server or cause a denial of service (Billion Laughs attack).
🔧 Fix: Replaced `xml.etree.ElementTree` with `defusedxml.ElementTree` which provides safe parsing defaults and added the `defusedxml` package as a dependency.
✅ Verification: The test parser still functions properly with the safer XML parser.

---
*PR created automatically by Jules for task [8075417946340525293](https://jules.google.com/task/8075417946340525293) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted dependency and import swap with no API changes; reduces attack surface on XML ingestion rather than altering auth or data flows.
> 
> **Overview**
> Mitigates **XML External Entity (XXE)** risk by switching XML parsing from the stdlib `xml.etree.ElementTree` to **`defusedxml.ElementTree`** wherever this PR touches parsing or examples.
> 
> **`defusedxml>=0.7.1`** is added as a project dependency (`pyproject.toml` / `uv.lock`). Runtime JUnit parsing in **`swarm/runtime/test_parser.py`** (`parse_junit_xml`) now uses the hardened parser for potentially untrusted report files. The selftest-core adoption doc’s custom JUnit reporter example is updated to match, and **`.jules/sentinel.md`** records the prevention pattern for future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bb83f0c8c774603c5f21f4bd395d657d4397835. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->