### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XML External Entity (XXE) vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2025-03-01 - Fix XXE vulnerability in test_parser.py
+**Vulnerability:** Use of insecure xml.etree.ElementTree to parse JUnit XML files in swarm/runtime/test_parser.py
+**Learning:** Standard library XML parsing in Python is vulnerable to XML External Entity (XXE) and billion laughs attacks, requiring defusedxml.
+**Prevention:** Always use defusedxml instead of standard library xml.etree for untrusted XML parsing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Security updates for medium-priority vulnerabilities
     "starlette>=0.46.0,<1.0.0",
     "urllib3>=2.3.0,<3.0.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/swarm/runtime/test_parser.py
+++ b/swarm/runtime/test_parser.py
@@ -35,11 +35,12 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+import defusedxml.ElementTree as ET
 
 from swarm.runtime.forensic_types import (
     FailureType,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -358,6 +368,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5,<2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0" },
     { name = "claude-agent-sdk", marker = "extra == 'dev'", specifier = ">=0.1.19" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix XML External Entity (XXE) vulnerability

🚨 Severity: CRITICAL
💡 Vulnerability: Used insecure standard library `xml.etree.ElementTree` to parse JUnit XML files in `swarm/runtime/test_parser.py`.
🎯 Impact: Susceptible to XML External Entity (XXE) and billion laughs attacks when parsing potentially untrusted test output files.
🔧 Fix: Added the `defusedxml` dependency and swapped `xml.etree.ElementTree` for `defusedxml.ElementTree` to parse XML safely.
✅ Verification: Ran pytest with the `parser` keyword (`uv run pytest tests -k "parser"`) to confirm the parser's functionality remains identical and no tests are broken.

---
*PR created automatically by Jules for task [14177376777052046020](https://jules.google.com/task/14177376777052046020) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive XML parsing for potentially untrusted test artifacts, but the change is a narrow drop-in library swap with limited call sites.
> 
> **Overview**
> Addresses **XXE / billion laughs** risk when JUnit XML from test runs is parsed in `swarm/runtime/test_parser.py` by replacing stdlib `xml.etree.ElementTree` with **`defusedxml.ElementTree`** (same `ET.parse` usage in `parse_junit_xml`).
> 
> Adds **`defusedxml>=0.7.1`** to project dependencies and refreshes **`uv.lock`**. Documents the incident and prevention guidance in **`.jules/sentinel.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b052add909ceca0e8c1339aa187778f0fb2e059a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->