### PR TITLE
🎨 Palette: Add ARIA attributes to Boundary Review toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-19 - Added ARIA attributes to Boundary Review panel toggle
+**Learning:** Icon-only toggle buttons should have both `aria-label` for description and dynamic `aria-expanded` to indicate state changes to screen readers.
+**Action:** Always verify custom toggle buttons include `aria-expanded` that updates in sync with the visual state.

--- a/swarm/tools/flow_studio_ui/src/boundary_review.ts
+++ b/swarm/tools/flow_studio_ui/src/boundary_review.ts
@@ -265,7 +265,7 @@ export function renderBoundaryReviewPanel(data: BoundaryReviewResponse): string 
       <div class="panel-header">
         <h3>Boundary Review</h3>
         ${data.current_flow ? `<span class="current-flow">Flow: ${data.current_flow}</span>` : ""}
-        <button class="toggle-expand" title="Toggle expand">
+        <button class="toggle-expand" title="Toggle expand" aria-label="Toggle boundary review expand" aria-expanded="${isExpanded}">
           ${isExpanded ? "▼" : "▶"}
         </button>
       </div>
@@ -345,6 +345,7 @@ export function setupBoundaryReviewHandlers(container: HTMLElement): void {
         sections.classList.toggle("collapsed", !isExpanded);
       }
       target.textContent = isExpanded ? "▼" : "▶";
+      target.setAttribute("aria-expanded", isExpanded.toString());
     }
   });
 }


### PR DESCRIPTION
Palette: Add ARIA attributes to Boundary Review toggle

💡 What: Added aria-label and dynamically updated aria-expanded to the Boundary Review toggle button.
🎯 Why: Improves screen reader accessibility for an icon-only interactive element.
📸 Before/After: Visuals unchanged.
♿ Accessibility: Screen reader users can now understand the button's purpose and its current expanded/collapsed state.

---
*PR created automatically by Jules for task [10793931388140911718](https://jules.google.com/task/10793931388140911718) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility-only markup and one DOM attribute update on click; no business logic or API changes.
> 
> **Overview**
> Improves screen reader support for the **Boundary Review** panel’s icon-only expand/collapse control by adding **`aria-label`** and an initial **`aria-expanded`** value tied to `isExpanded`.
> 
> On toggle, the click handler now **syncs `aria-expanded`** with the updated expanded state (alongside the existing arrow and section class updates). A **`.jules/palette.md`** note documents the pattern for future icon-only toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8ab26a9d191208d031e4ed6da9b4570a55a8d38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->