### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XXE Vulnerability in XML Parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-06-19 - Prevent XXE Vulnerabilities
+**Vulnerability:** Found use of standard xml.etree.ElementTree in test_parser.py which is vulnerable to XXE and billion laughs attacks when parsing untrusted JUnit XML.
+**Learning:** Test parsers often process externally generated files, requiring the same security scrutiny as user input.
+**Prevention:** Always use defusedxml.ElementTree instead of xml.etree.ElementTree when parsing XML files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Security updates for medium-priority vulnerabilities
     "starlette>=0.46.0,<1.0.0",
     "urllib3>=2.3.0,<3.0.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/swarm/runtime/test_parser.py
+++ b/swarm/runtime/test_parser.py
@@ -35,11 +35,12 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+import defusedxml.ElementTree as ET
 
 from swarm.runtime.forensic_types import (
     FailureType,

--- a/tests/test_xml_protection.py
+++ b/tests/test_xml_protection.py
@@ -1,0 +1,60 @@
+import pytest
+from pathlib import Path
+from swarm.runtime.test_parser import parse_junit_xml
+
+def test_xml_external_entity_protection(tmp_path: Path):
+    """Verify that the XML parser is protected against XXE attacks."""
+
+    # Create a malicious XML file with an external entity
+    xxe_xml = tmp_path / "xxe_test.xml"
+    xxe_xml.write_text("""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE test [
+  <!ENTITY xxe SYSTEM "file:///etc/passwd">
+]>
+<testsuites>
+  <testsuite name="&xxe;" tests="1" failures="0" errors="0" skipped="0" time="0.1">
+    <testcase name="test_example" classname="example.Test" time="0.05" />
+  </testsuite>
+</testsuites>
+""")
+
+    try:
+        parse_junit_xml(xxe_xml)
+        pytest.fail("Exception not raised")
+    except Exception as e:
+        if str(e) == "Exception not raised":
+            raise
+        assert "Entities" in str(type(e).__name__) or "DTD" in str(type(e).__name__)
+
+def test_billion_laughs_protection(tmp_path: Path):
+    """Verify that the XML parser is protected against billion laughs attacks."""
+
+    # Create a malicious XML file with nested entities
+    bl_xml = tmp_path / "billion_laughs.xml"
+    bl_xml.write_text("""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+  <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+  <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+  <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+  <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<testsuites>
+  <testsuite name="&lol9;" tests="1" failures="0" errors="0" skipped="0" time="0.1">
+    <testcase name="test_example" classname="example.Test" time="0.05" />
+  </testsuite>
+</testsuites>
+""")
+
+    try:
+        parse_junit_xml(bl_xml)
+        pytest.fail("Exception not raised")
+    except Exception as e:
+        if str(e) == "Exception not raised":
+            raise
+        assert "Entities" in str(type(e).__name__) or "DTD" in str(type(e).__name__)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -358,6 +368,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5,<2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0" },
     { name = "claude-agent-sdk", marker = "extra == 'dev'", specifier = ">=0.1.19" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix XXE Vulnerability in XML Parser

🚨 Severity: CRITICAL
💡 Vulnerability: The test parser used `xml.etree.ElementTree` which is vulnerable to XML External Entity (XXE) and Billion Laughs attacks when parsing untrusted XML test results.
🎯 Impact: Attackers could potentially read arbitrary files on the system or cause Denial of Service (DoS) by providing a malicious JUnit XML file.
🔧 Fix: Replaced `xml.etree.ElementTree` with `defusedxml.ElementTree` to safely parse XML test results. Added guardrail tests.
✅ Verification: Ensure the provided tests (`tests/test_xml_protection.py`) pass, proving entities are blocked.

---
*PR created automatically by Jules for task [4371789475462983323](https://jules.google.com/task/4371789475462983323) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted security hardening with a drop-in parser swap and new tests; behavior for valid JUnit XML should stay the same while malicious XML is rejected.
> 
> **Overview**
> **JUnit XML parsing** in `test_parser.py` now uses **`defusedxml.ElementTree`** instead of the standard library **`xml.etree.ElementTree`**, so malicious JUnit files cannot trigger XXE file reads or billion-laughs DoS when forensic code ingests untrusted test output.
> 
> The project adds **`defusedxml>=0.7.1`** as a runtime dependency (with lockfile updates). **`tests/test_xml_protection.py`** asserts that `parse_junit_xml` rejects external-entity and nested-entity payloads. **`.jules/sentinel.md`** records the finding and the prevention rule for future work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96e4bc16d52af0ac6ecfcff63aa14c63612fff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->