### PR TITLE
🛡️ Sentinel: [HIGH] Fix XXE vulnerability in JUnit XML parser

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2026-06-20 - Prevent XXE vulnerabilities by replacing xml.etree with defusedxml
+**Vulnerability:** Found standard library 'xml.etree.ElementTree' usage in 'swarm/runtime/test_parser.py' which is vulnerable to XML External Entity (XXE) and billion laughs attacks.
+**Learning:** Standard XML parser does not protect against malicious XML documents with malicious entity definitions. This can lead to DoS or local file read.
+**Prevention:** Always use 'defusedxml.ElementTree' for XML parsing in Python, especially when handling third-party or untrusted XML inputs like JUnit XML reports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Security updates for medium-priority vulnerabilities
     "starlette>=0.46.0,<1.0.0",
     "urllib3>=2.3.0,<3.0.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/swarm/runtime/test_parser.py
+++ b/swarm/runtime/test_parser.py
@@ -35,11 +35,12 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+import defusedxml.ElementTree as ET
 
 from swarm.runtime.forensic_types import (
     FailureType,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -358,6 +368,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5,<2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0" },
     { name = "claude-agent-sdk", marker = "extra == 'dev'", specifier = ">=0.1.19" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `swarm/runtime/test_parser.py` uses `xml.etree.ElementTree` to parse external JUnit XML files, which is vulnerable to XXE (XML External Entity) and billion laughs attacks.
🎯 Impact: If malicious test output XML is processed, an attacker could potentially read local files or cause a Denial of Service.
🔧 Fix: Replaced `xml.etree.ElementTree` with `defusedxml.ElementTree`, which safely handles untrusted XML data.
✅ Verification: Run `uv run pytest -k "test_parser"` to verify parser functionality remains intact with the new library.

---
*PR created automatically by Jules for task [17939967687014245740](https://jules.google.com/task/17939967687014245740) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Drop-in parser swap with a small new dependency; no API or logic changes beyond safer XML handling.
> 
> **Overview**
> Hardens JUnit XML parsing in `swarm/runtime/test_parser.py` by swapping **`xml.etree.ElementTree`** for **`defusedxml.ElementTree`**, so untrusted JUnit reports are not parsed with a XXE- and billion-laughs-vulnerable stdlib parser. **`defusedxml>=0.7.1`** is added to **`pyproject.toml`** with **`uv.lock`** updated accordingly.
> 
> Documents the finding and prevention guidance in **`.jules/sentinel.md`**. Parsing behavior in `parse_junit_xml` is unchanged aside from the safer backend.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36c8d4166f361ef8600480d1c886d3f03a775651. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->