### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XML External Entity (XXE) vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-06-20 - Replace standard XML parser with defusedxml
+**Vulnerability:** The standard library `xml.etree.ElementTree` was used for XML parsing, which is vulnerable to XML External Entity (XXE) and billion laughs attacks.
+**Learning:** The built-in XML parser is insecure by default. It's critical to use secure alternatives when parsing potentially untrusted XML files.
+**Prevention:** Always use `defusedxml` instead of the standard library `xml` module when parsing XML files in this repository.

--- a/docs/ADOPTING_SELFTEST_CORE.md
+++ b/docs/ADOPTING_SELFTEST_CORE.md
@@ -1254,7 +1254,7 @@ Create custom output formats:
 
 ```python
 from selftest_core.reporter import ReportGenerator
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 class JUnitReporter:
     """Generate JUnit XML reports for CI systems."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Security updates for medium-priority vulnerabilities
     "starlette>=0.46.0,<1.0.0",
     "urllib3>=2.3.0,<3.0.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/swarm/runtime/test_parser.py
+++ b/swarm/runtime/test_parser.py
@@ -35,11 +35,12 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+import defusedxml.ElementTree as ET
 
 from swarm.runtime.forensic_types import (
     FailureType,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -358,6 +368,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5,<2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0" },
     { name = "claude-agent-sdk", marker = "extra == 'dev'", specifier = ">=0.1.19" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The standard library `xml.etree.ElementTree` was used for XML parsing, which is vulnerable to XML External Entity (XXE) and billion laughs attacks.
🎯 Impact: An attacker could potentially exploit this to cause Denial of Service (DoS) or unauthorized file access.
🔧 Fix: Replaced `xml.etree.ElementTree` with `defusedxml.ElementTree` across the codebase and added it to dependencies.
✅ Verification: The codebase now uses `defusedxml`, and manual verification confirms that `parse_junit_xml` runs successfully without breaking functionality.

---
*PR created automatically by Jules for task [4391721693634503098](https://jules.google.com/task/4391721693634503098) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Security-hardening swap with a drop-in API; main residual risk is if defusedxml rejects edge-case XML that the stdlib accepted.
> 
> **Overview**
> Mitigates **XXE** and **billion laughs** risk by dropping `xml.etree.ElementTree` for **`defusedxml.ElementTree`** wherever JUnit-style XML is parsed or documented.
> 
> **`swarm/runtime/test_parser.py`** now uses defusedxml for `parse_junit_xml` (forensic JUnit ingestion). **`docs/ADOPTING_SELFTEST_CORE.md`** updates the custom JUnit reporter example to match. **`defusedxml>=0.7.1`** is added to **`pyproject.toml`** and **`uv.lock`**. **`.jules/sentinel.md`** records the vulnerability, fix, and repo rule to prefer defusedxml for untrusted XML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55a8e9d762ed1b8af25939b0d69c30e64f6d3386. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->