### PR TITLE
🎨 Palette: Improve screen reader experience on icon-only buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-20 - Prevent Redundant Screen Reader Announcements in Icon-Only Buttons
+**Learning:** When an icon-only button contains a literal text character (like '×' or '+') acting as an icon, and the button already has an `aria-label` for screen readers, the literal character should be wrapped in a `<span aria-hidden="true">`. Otherwise, screen readers will redundantly announce both the descriptive label and the literal character.
+**Action:** Always wrap literal text characters acting as icons in `aria-hidden="true"` when their parent element already has a descriptive `aria-label`.

--- a/swarm/tools/flow_studio_ui/src/components/BoundaryReview.ts
+++ b/swarm/tools/flow_studio_ui/src/components/BoundaryReview.ts
@@ -270,7 +270,7 @@ export class BoundaryReview {
               </div>
             </div>
           </div>
-          <button class="boundary-review__close" data-action="close" aria-label="Close">\u00d7</button>
+          <button class="boundary-review__close" data-action="close" aria-label="Close"><span aria-hidden="true">\u00d7</span></button>
         </div>
 
         <div class="boundary-review__body">

--- a/swarm/tools/flow_studio_ui/src/components/NodeInspector.ts
+++ b/swarm/tools/flow_studio_ui/src/components/NodeInspector.ts
@@ -481,7 +481,7 @@ export class NodeInspector {
       tagsContainer.innerHTML = values.map(v => `
         <span class="node-inspector__tag">
           ${escapeHtml(v)}
-          <button type="button" class="node-inspector__tag-remove" data-value="${escapeHtml(v)}" aria-label="Remove agent" title="Remove agent">\u00D7</button>
+          <button type="button" class="node-inspector__tag-remove" data-value="${escapeHtml(v)}" aria-label="Remove agent" title="Remove agent"><span aria-hidden="true">\u00D7</span></button>
         </span>
       `).join("");
 
@@ -543,7 +543,7 @@ export class NodeInspector {
         <div class="node-inspector__list-items"></div>
         <div class="node-inspector__list-add">
           <input type="text" class="node-inspector__list-add-input" placeholder="${escapeHtml(placeholder)}" />
-          <button type="button" class="node-inspector__list-add-btn" aria-label="Add item" title="Add item">+</button>
+          <button type="button" class="node-inspector__list-add-btn" aria-label="Add item" title="Add item"><span aria-hidden="true">+</span></button>
         </div>
       </div>
     `;
@@ -557,7 +557,7 @@ export class NodeInspector {
       itemsContainer.innerHTML = values.map((v, i) => `
         <div class="node-inspector__list-item">
           <span class="node-inspector__list-item-text mono">${escapeHtml(v)}</span>
-          <button type="button" class="node-inspector__list-item-remove" data-index="${i}" aria-label="Remove item" title="Remove item">\u00D7</button>
+          <button type="button" class="node-inspector__list-item-remove" data-index="${i}" aria-label="Remove item" title="Remove item"><span aria-hidden="true">\u00D7</span></button>
         </div>
       `).join("");
 

--- a/swarm/tools/flow_studio_ui/src/components/ValidationModal.ts
+++ b/swarm/tools/flow_studio_ui/src/components/ValidationModal.ts
@@ -404,7 +404,7 @@ export class ValidationModal {
           <h2 class="validation-modal-title" id="validation-modal-title">
             ${hasCritical ? "Cannot Save - Critical Errors" : "Validation Warnings"}
           </h2>
-          <button class="validation-modal-close" data-action="close" aria-label="Close">\u00d7</button>
+          <button class="validation-modal-close" data-action="close" aria-label="Close"><span aria-hidden="true">\u00d7</span></button>
         </div>
 
         <div class="validation-modal-body">

--- a/swarm/tools/flow_studio_ui/src/run_detail_modal.ts
+++ b/swarm/tools/flow_studio_ui/src/run_detail_modal.ts
@@ -83,7 +83,7 @@ function getOrCreateModal(): HTMLElement {
 
   modal.innerHTML = `
     <div class="selftest-step-content" data-uiid="flow_studio.modal.run_detail.body">
-      <button class="selftest-modal-close" data-uiid="flow_studio.modal.run_detail.close" aria-label="Close modal">&times;</button>
+      <button class="selftest-modal-close" data-uiid="flow_studio.modal.run_detail.close" aria-label="Close modal"><span aria-hidden="true">&times;</span></button>
       <div id="run-detail-modal-content">
         <div class="muted">Loading...</div>
       </div>


### PR DESCRIPTION
🎨 Palette: Improve screen reader experience on icon-only buttons

💡 What: Wrapped literal text characters ('×' and '+') in `<span aria-hidden="true">` across multiple icon-only buttons that already have an `aria-label`.

🎯 Why: To prevent screen readers from redundantly announcing both the descriptive label and the literal character, making navigation cleaner and more professional.

📸 Before/After: Visuals remain unchanged, but screen reader experience is improved.

♿ Accessibility: Directly targets an issue where icon characters break the semantic purity of ARIA labels.

---
*PR created automatically by Jules for task [1813179482657578027](https://jules.google.com/task/1813179482657578027) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only HTML/accessibility tweaks with no logic or API changes; verify NodeInspector remove clicks still work if users click the glyph (handlers use e.target).
> 
> **Overview**
> Icon-only buttons in Flow Studio that already expose an **`aria-label`** no longer leave their visible **×** or **+** characters in the accessibility tree. Those glyphs are wrapped in **`<span aria-hidden="true">`** so assistive tech should announce only the label (e.g. “Close”, “Remove item”, “Add item”), not “Close times” or similar.
> 
> The markup updates span modal close controls in **BoundaryReview**, **ValidationModal**, and **run detail**, plus tag/list remove and add actions in **NodeInspector**. A short **`.jules/palette.md`** entry documents the pattern for future UI work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13a58d6fdfd405afb257fcbab259bd3bb013af68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->