### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XXE Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-18 - Prevent XXE Vulnerabilities
+**Vulnerability:** Use of insecure xml.etree.ElementTree for parsing XML.
+**Learning:** The standard library's ElementTree is vulnerable to XML External Entity (XXE) and billion laughs attacks when parsing untrusted XML.
+**Prevention:** Always use defusedxml.ElementTree instead of the standard library when parsing XML files.

--- a/docs/ADOPTING_SELFTEST_CORE.md
+++ b/docs/ADOPTING_SELFTEST_CORE.md
@@ -1254,7 +1254,7 @@ Create custom output formats:
 
 ```python
 from selftest_core.reporter import ReportGenerator
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 
 class JUnitReporter:
     """Generate JUnit XML reports for CI systems."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Security updates for medium-priority vulnerabilities
     "starlette>=0.46.0,<1.0.0",
     "urllib3>=2.3.0,<3.0.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/swarm/runtime/test_parser.py
+++ b/swarm/runtime/test_parser.py
@@ -35,11 +35,12 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+
+import defusedxml.ElementTree as ET
 
 from swarm.runtime.forensic_types import (
     FailureType,

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -358,6 +368,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5,<2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0" },
     { name = "claude-agent-sdk", marker = "extra == 'dev'", specifier = ">=0.1.19" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix XXE Vulnerability

🚨 Severity: CRITICAL
💡 Vulnerability: The test parser was using the standard library's `xml.etree.ElementTree` to parse JUnit XML files, which is vulnerable to XML External Entity (XXE) and billion laughs attacks.
🎯 Impact: An attacker could provide a malicious XML file that, when parsed, could read arbitrary files on the system or cause a Denial of Service (DoS).
🔧 Fix: Replaced `xml.etree.ElementTree` with `defusedxml.ElementTree`, which protects against these vulnerabilities by disabling external entity resolution and expansion.
✅ Verification: Run `uv run pytest tests/test_yaml_parser.py` to ensure XML parsing functionality is preserved with the new library.

---
*PR created automatically by Jules for task [14845989269664385056](https://jules.google.com/task/14845989269664385056) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted security hardening with a drop-in ElementTree API; behavior for normal JUnit XML should stay the same while blocking malicious XML.
> 
> **Overview**
> **Mitigates XXE and billion-laughs risk** when parsing JUnit XML by switching from stdlib `xml.etree.ElementTree` to **`defusedxml.ElementTree`** in `swarm/runtime/test_parser.py` (`parse_junit_xml`).
> 
> Adds **`defusedxml>=0.7.1`** as a project dependency (`pyproject.toml`, `uv.lock`). The selftest-core adoption doc’s JUnit reporter example is updated to match. **`.jules/sentinel.md`** records the vulnerability pattern and the rule to use defusedxml for untrusted XML.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ea999ec52a917e48fa572608e13daab62a827ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->