### PR TITLE
🎨 Palette: Fix redundant screen reader announcements on close buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2026-06-21 - Screen Reader Redundancy in Icon-only Buttons
+**Learning:** When icon-only buttons use literal text characters (like '×' or '&times;') as the icon and have an `aria-label`, screen readers will redundantly announce both the label and the literal character.
+**Action:** Always wrap literal text characters acting as icons in a `<span aria-hidden="true">`, particularly when the button already has an `aria-label` to prevent redundant and confusing screen reader announcements.

--- a/swarm/tools/flow_studio_ui/fragments/60-modals.html
+++ b/swarm/tools/flow_studio_ui/fragments/60-modals.html
@@ -1,7 +1,7 @@
 <!-- Selftest step explanation modal -->
 <div id="selftest-modal" class="selftest-modal" role="dialog" aria-modal="true" aria-labelledby="selftest-modal-title" data-uiid="flow_studio.modal.selftest">
   <div class="selftest-step-content">
-    <button class="selftest-modal-close" onclick="toggleSelftestModal(false)" aria-label="Close selftest modal" data-uiid="flow_studio.modal.selftest.close">×</button>
+    <button class="selftest-modal-close" onclick="toggleSelftestModal(false)" aria-label="Close selftest modal" data-uiid="flow_studio.modal.selftest.close"><span aria-hidden="true">×</span></button>
     <h3 id="selftest-modal-title" class="visually-hidden">Selftest Step Details</h3>
     <div id="selftest-modal-body" data-uiid="flow_studio.modal.selftest.body">Loading...</div>
   </div>
@@ -10,7 +10,7 @@
 <!-- Keyboard shortcuts modal -->
 <div id="shortcuts-modal" class="shortcuts-modal" role="dialog" aria-modal="true" aria-labelledby="shortcuts-modal-title" data-uiid="flow_studio.modal.shortcuts">
   <div class="shortcuts-content">
-    <button id="shortcuts-modal-close" class="selftest-modal-close" aria-label="Close shortcuts modal" data-uiid="flow_studio.modal.shortcuts.close">×</button>
+    <button id="shortcuts-modal-close" class="selftest-modal-close" aria-label="Close shortcuts modal" data-uiid="flow_studio.modal.shortcuts.close"><span aria-hidden="true">×</span></button>
     <h3 id="shortcuts-modal-title">Keyboard Shortcuts</h3>
     <div class="shortcut-row">
       <span class="shortcut-desc">Focus search</span>
@@ -66,7 +66,7 @@
 <!-- Run Detail Modal -->
 <div id="run-detail-modal" class="selftest-modal" role="dialog" aria-modal="true" aria-labelledby="run-detail-modal-title" data-uiid="flow_studio.modal.run_detail">
   <div class="selftest-step-content" data-uiid="flow_studio.modal.run_detail.body">
-    <button class="selftest-modal-close" id="run-detail-close" aria-label="Close run detail modal" data-uiid="flow_studio.modal.run_detail.close">×</button>
+    <button class="selftest-modal-close" id="run-detail-close" aria-label="Close run detail modal" data-uiid="flow_studio.modal.run_detail.close"><span aria-hidden="true">×</span></button>
     <div id="run-detail-modal-content">
       <div class="muted">Loading...</div>
     </div>

--- a/swarm/tools/flow_studio_ui/fragments/65-context-budget-modal.html
+++ b/swarm/tools/flow_studio_ui/fragments/65-context-budget-modal.html
@@ -4,7 +4,7 @@
      data-uiid="flow_studio.modal.context_budget">
   <div class="settings-content">
     <button class="modal-close" aria-label="Close"
-            data-uiid="flow_studio.modal.context_budget.close">&times;</button>
+            data-uiid="flow_studio.modal.context_budget.close"><span aria-hidden="true">&times;</span></button>
 
     <h3 id="context-budget-modal-title">Context Budget Settings</h3>
     <p class="settings-description">

--- a/swarm/tools/flow_studio_ui/src/run_detail_modal.ts
+++ b/swarm/tools/flow_studio_ui/src/run_detail_modal.ts
@@ -83,7 +83,7 @@ function getOrCreateModal(): HTMLElement {
 
   modal.innerHTML = `
     <div class="selftest-step-content" data-uiid="flow_studio.modal.run_detail.body">
-      <button class="selftest-modal-close" data-uiid="flow_studio.modal.run_detail.close" aria-label="Close modal">&times;</button>
+      <button class="selftest-modal-close" data-uiid="flow_studio.modal.run_detail.close" aria-label="Close modal"><span aria-hidden="true">&times;</span></button>
       <div id="run-detail-modal-content">
         <div class="muted">Loading...</div>
       </div>


### PR DESCRIPTION
💡 What: Wrapped literal text characters ('×' and '&times;') in close buttons with `<span aria-hidden="true">`.
🎯 Why: Screen readers were redundantly announcing both the descriptive `aria-label` ("Close modal") and the literal character ("times" or "multiplication sign"), creating a confusing and verbose experience.
📸 Before/After: N/A (invisible DOM change).
♿ Accessibility: Improved screen reader experience by hiding decorative text characters from assistive technologies when a descriptive `aria-label` is already present.

---
*PR created automatically by Jules for task [7672710728768899216](https://jules.google.com/task/7672710728768899216) started by @EffortlessSteven*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DOM-only accessibility markup with no behavior or API changes; visual appearance is unchanged.
> 
> **Overview**
> Flow Studio modal **close** controls that use `×` / `&times;` as the visible icon now wrap that character in `<span aria-hidden="true">` while keeping the existing `aria-label`, so assistive tech should hear only the label (e.g. “Close shortcuts modal”) instead of the label plus “times” or “multiplication sign.”
> 
> The same markup update is applied across **selftest**, **keyboard shortcuts**, **run detail**, and **context budget** modals in the HTML fragments, and in the **dynamically created** run-detail modal in `run_detail_modal.ts`. A short **`.jules/palette.md`** note documents the pattern for future icon-only buttons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6912738fa44e90d65e39d9b507a9042398e25c2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->