### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XXE Vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-06-24 - Prevent XXE Vulnerabilities
+**Vulnerability:** Used standard xml.etree.ElementTree to parse XML test outputs, which is vulnerable to XXE and Billion Laughs attacks.
+**Learning:** The built-in Python XML parser is inherently unsafe when handling untrusted/external XML files. This repository specifically requires defusedxml.ElementTree to be used for all XML parsing as noted in the Sentinel rules.
+**Prevention:** Always use the defusedxml package as a drop-in replacement for xml.etree when parsing any XML content.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     # Security updates for medium-priority vulnerabilities
     "starlette>=0.46.0,<1.0.0",
     "urllib3>=2.3.0,<3.0.0",
+    "defusedxml>=0.7.1",
 ]
 
 [project.optional-dependencies]

--- a/swarm/runtime/test_parser.py
+++ b/swarm/runtime/test_parser.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 import zipfile
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [[package]]
@@ -276,6 +276,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "duckdb"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -318,6 +327,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "authlib" },
+    { name = "defusedxml" },
     { name = "duckdb" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -358,6 +368,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.6.5,<2.0.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=25.11.0" },
     { name = "claude-agent-sdk", marker = "extra == 'dev'", specifier = ">=0.1.19" },
+    { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "fastapi", specifier = ">=0.124.0" },
     { name = "httpx", specifier = ">=0.28.1" },


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Used `xml.etree.ElementTree` which is vulnerable to XML External Entity (XXE) attacks when parsing untrusted XML data (like test output/reports).
🎯 Impact: Attackers could read arbitrary files, perform denial of service (Billion Laughs), or execute SSRF attacks if they can control the XML test output processed by the system.
🔧 Fix: Switched from `xml.etree.ElementTree` to the secure `defusedxml.ElementTree` drop-in replacement which disables entity expansion and external entities by default.
✅ Verification: Ensure the module `swarm/runtime/test_parser.py` uses `import defusedxml.ElementTree as ET` and tests pass via `uv run pytest tests/test_yaml_parser.py`.

---
*PR created automatically by Jules for task [10276577124174419339](https://jules.google.com/task/10276577124174419339) started by @EffortlessSteven*