### PR TITLE
⚡ Bolt: Replace Path.iterdir() with os.scandir in list_runs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2026-01-23 - Defer File Existence Checks
 **Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast.
 **Action:** Sort candidates by cached metadata (e.g. mtime from `os.scandir`) first, then only perform expensive checks (like file existence or loading content) on the top N results that will actually be returned.
+## 2026-06-26 - Optimize directory iteration
+**Learning:** When listing items from a large directory (e.g. 50k runs), checking file existence (`os.path.exists`) for every item is a significant bottleneck, even if the check is fast. The `os.scandir` command is much faster than `Path.iterdir()`.
+**Action:** Use `os.scandir` and extract entries in sorting before instantiating objects to avoid performance bottlenecks.

--- a/swarm/api/services/spec_manager.py
+++ b/swarm/api/services/spec_manager.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
+import os
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
@@ -503,10 +504,16 @@ class SpecManager:
         if not self.runs_root.exists():
             return runs
 
-        for run_dir in sorted(self.runs_root.iterdir(), reverse=True):
-            if not run_dir.is_dir():
-                continue
+        # ⚡ Bolt: Optimize directory listing for large run histories
+        # os.scandir is much faster than Path.iterdir() as it doesn't instantiate Path objects for every entry
+        try:
+            with os.scandir(self.runs_root) as it:
+                run_names = sorted([entry.name for entry in it if entry.is_dir()], reverse=True)
+        except OSError:
+            return runs
 
+        for run_name in run_names:
+            run_dir = self.runs_root / run_name
             state_file = run_dir / "run_state.json"
             if state_file.exists():
                 try:


### PR DESCRIPTION
💡 What: Modified `list_runs` in `swarm/api/services/spec_manager.py` to use `os.scandir` instead of `Path.iterdir()`.
🎯 Why: When fetching a list of recent runs in a directory that may contain thousands of entries, `Path.iterdir()` is inefficient because it instantiates `Path` objects for every single entry in the directory. `os.scandir` yields lightweight string entries which we can then sort before instantiating `Path` objects only for the items we actually process.
📊 Impact: Reduces iteration time significantly for large directories.
🔬 Measurement: Tested locally by verifying test coverage and testing iteration time between `Path.iterdir()` and `os.scandir()`.

---
*PR created automatically by Jules for task [13702075110009013209](https://jules.google.com/task/13702075110009013209) started by @EffortlessSteven*