### PR TITLE
🛡️ Sentinel: [HIGH] Fix SQL injection in db stats

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-24 - SQL Injection in db.py
+**Vulnerability:** Unparameterized table name in SELECT COUNT query.
+**Learning:** DuckDB cannot parameterize table names, requiring explicit validation.
+**Prevention:** Always validate table identifiers against a strict allowlist before formatting into queries.

--- a/swarm/api/routes/db.py
+++ b/swarm/api/routes/db.py
@@ -239,14 +239,16 @@ async def get_db_stats():
             )
 
         conn = stats_db.connection
-
         # Query counts from each table
         def safe_count(table: str) -> int:
+            if table not in {"runs", "steps", "tool_calls", "file_changes", "events", "facts"}:
+                return 0
             try:
                 result = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
                 return result[0] if result else 0
             except Exception:
                 return 0
+
 
         return DBStatsResponse(
             total_runs=safe_count("runs"),


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix SQL injection in db stats

🚨 Severity: HIGH

💡 Vulnerability: The `get_db_stats` endpoint uses string interpolation to dynamically format table names into a DuckDB SQL query, creating a potential SQL injection vulnerability.

🎯 Impact: An attacker could potentially inject malicious SQL to access arbitrary tables, extract sensitive data, or perform destructive operations against the DuckDB database.

🔧 Fix: Validated the `table` identifier against a strict allowlist of known tables before formatting the SQL query. This safely prevents any untrusted or injected table names from being executed.

✅ Verification: Verified that the endpoint continues to return correct database statistics using valid tables, and any invalid table request gracefully returns 0 without executing a query. Ensure no functionality or existing tests are broken.

---
*PR created automatically by Jules for task [2144616850464522144](https://jules.google.com/task/2144616850464522144) started by @EffortlessSteven*