### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SQL injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2025-07-01 - SQL Injection via f-strings in DuckDB
+**Vulnerability:** SQL injection in DuckDB via f-strings for table names
+**Learning:** Standard SQL and DuckDB parameterization syntax only supports values, not table names or identifiers. So it is easy to accidentally write f-string queries.
+**Prevention:** To securely handle dynamic table names and prevent SQL injection, validate the identifier against a strict hardcoded allowlist in Python before formatting it into the query string.

--- a/swarm/api/routes/db.py
+++ b/swarm/api/routes/db.py
@@ -242,6 +242,11 @@ async def get_db_stats():
 
         # Query counts from each table
         def safe_count(table: str) -> int:
+            # Prevent SQL injection by validating table name against allowlist
+            allowed_tables = {"runs", "steps", "tool_calls", "file_changes", "events", "facts", "routing_decisions"}
+            if table not in allowed_tables:
+                return 0
+
             try:
                 result = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
                 return result[0] if result else 0


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix SQL injection

🚨 Severity: CRITICAL
💡 Vulnerability: SQL injection in DuckDB via f-strings for table names
🎯 Impact: An attacker could execute arbitrary SQL queries, leading to data exposure, modification, or denial of service.
🔧 Fix: Validated table names against a strict hardcoded allowlist before inserting them into the SQL query string.
✅ Verification: Ensure all resilient_db and db_projection tests pass, and verify stats API calls continue to work normally.

---
*PR created automatically by Jules for task [17834910374550580244](https://jules.google.com/task/17834910374550580244) started by @EffortlessSteven*