### PR TITLE
fix: establish the canonical run spine

### DIFF
--- a/swarm/api/routes/autopilot_routes.py
+++ b/swarm/api/routes/autopilot_routes.py
@@ -1,12 +1,4 @@
-"""
-Autopilot endpoints for Flow Studio API.
-
-Provides REST endpoints for:
-- Starting autopilot runs
-- Getting autopilot status
-- Ticking autopilot forward
-- Canceling/stopping/pausing/resuming autopilot runs
-"""
+"""API routes for durable multi-flow autopilot runs."""
 
 from __future__ import annotations
 
@@ -17,19 +9,13 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
-logger = logging.getLogger(__name__)
+from swarm.runtime.safe_paths import validate_path_component
 
+logger = logging.getLogger(__name__)
 router = APIRouter(tags=["autopilot"])
 
 
-# =============================================================================
-# Pydantic Models
-# =============================================================================
-
-
 class RunActionResponse(BaseModel):
-    """Generic response for run actions."""
-
     run_id: str
     status: str
     message: str
@@ -37,26 +23,17 @@ class RunActionResponse(BaseModel):
 
 
 class AutopilotStartRequest(BaseModel):
-    """Request to start an autopilot run."""
-
-    issue_ref: Optional[str] = Field(None, description="Issue reference (e.g., 'owner/repo#123')")
-    flow_keys: Optional[List[str]] = Field(
-        None, description="Specific flows to execute (defaults to all SDLC flows)"
-    )
-    profile_id: Optional[str] = Field(None, description="Profile ID to use")
-    backend: str = Field("claude-step-orchestrator", description="Backend for execution")
-    params: Optional[Dict[str, Any]] = Field(None, description="Additional parameters")
-    auto_apply_wisdom: bool = Field(False, description="Auto-apply wisdom patches at run end")
-    auto_apply_policy: str = Field("safe", description="Policy for auto-apply: 'safe' or 'all'")
-    auto_apply_patch_types: Optional[List[str]] = Field(
-        None,
-        description="Patch types to auto-apply (defaults to ['flow_evolution', 'station_tuning'])",
-    )
+    issue_ref: Optional[str] = Field(None, description="Issue reference, for example owner/repo#123")
+    flow_keys: Optional[List[str]] = Field(None, description="Flows to execute")
+    profile_id: Optional[str] = None
+    backend: str = "claude-step-orchestrator"
+    params: Optional[Dict[str, Any]] = None
+    auto_apply_wisdom: bool = False
+    auto_apply_policy: str = "safe"
+    auto_apply_patch_types: Optional[List[str]] = None
 
 
 class AutopilotStartResponse(BaseModel):
-    """Response when starting an autopilot run."""
-
     run_id: str
     status: str
     flows: List[str]
@@ -65,8 +42,6 @@ class AutopilotStartResponse(BaseModel):
 
 
 class WisdomApplyResultResponse(BaseModel):
-    """Summary of wisdom auto-apply results."""
-
     patches_processed: int = 0
     patches_applied: int = 0
     patches_rejected: int = 0
@@ -75,8 +50,6 @@ class WisdomApplyResultResponse(BaseModel):
 
 
 class AutopilotStatusResponse(BaseModel):
-    """Response for autopilot status check."""
-
     run_id: str
     status: str
     current_flow: Optional[str] = None
@@ -88,54 +61,56 @@ class AutopilotStatusResponse(BaseModel):
 
 
 class AutopilotStopRequest(BaseModel):
-    """Request to stop an autopilot run gracefully."""
-
-    reason: str = Field("user_initiated", description="Reason for stopping")
+    reason: str = "user_initiated"
 
 
-# Global autopilot controller (initialized on first use)
 _autopilot_controller = None
 
 
 def _get_autopilot_controller():
-    """Get or create the global autopilot controller."""
+    """Return the API-facing controller that owns a canonical run identity."""
     global _autopilot_controller
     if _autopilot_controller is None:
-        from swarm.runtime.autopilot import AutopilotController
+        from swarm.runtime.canonical_autopilot import CanonicalAutopilotController
 
-        _autopilot_controller = AutopilotController()
+        _autopilot_controller = CanonicalAutopilotController()
     return _autopilot_controller
 
 
-# =============================================================================
-# Autopilot Endpoints
-# =============================================================================
+def _validate_run_id(run_id: str) -> None:
+    try:
+        validate_path_component(run_id, "run_id")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _status_response(controller, run_id: str) -> AutopilotStatusResponse:
+    result = controller.get_result(run_id)
+    wisdom_result = None
+    if result.wisdom_apply_result:
+        wisdom_result = WisdomApplyResultResponse(
+            patches_processed=result.wisdom_apply_result.patches_processed,
+            patches_applied=result.wisdom_apply_result.patches_applied,
+            patches_rejected=result.wisdom_apply_result.patches_rejected,
+            patches_skipped=result.wisdom_apply_result.patches_skipped,
+            applied_patch_ids=result.wisdom_apply_result.applied_patch_ids,
+        )
+    return AutopilotStatusResponse(
+        run_id=run_id,
+        status=result.status.value,
+        current_flow=result.current_flow,
+        flows_completed=result.flows_completed,
+        flows_failed=result.flows_failed,
+        error=result.error,
+        duration_ms=result.duration_ms,
+        wisdom_apply_result=wisdom_result,
+    )
 
 
 @router.post("", response_model=AutopilotStartResponse, status_code=201)
 async def start_autopilot(request: AutopilotStartRequest):
-    """Start an autopilot run for end-to-end SDLC execution.
-
-    Creates a new run configured for autonomous execution. All flows are
-    executed sequentially without mid-flow human intervention. PAUSE intents
-    are automatically rewritten to DETOUR (clarifier sidequest).
-
-    When auto_apply_wisdom is enabled, wisdom patches will be automatically
-    applied at run completion using the specified policy:
-    - 'safe': Only applies patches that pass schema validation, compile preview,
-              and don't require human review.
-    - 'all': Applies all valid patches regardless of review requirements.
-
-    Args:
-        request: Autopilot start request with optional issue_ref, flow configuration,
-                 and auto-apply wisdom settings.
-
-    Returns:
-        AutopilotStartResponse with run_id and scheduled flows.
-    """
     try:
         controller = _get_autopilot_controller()
-
         run_id = controller.start(
             issue_ref=request.issue_ref,
             flow_keys=request.flow_keys,
@@ -147,9 +122,7 @@ async def start_autopilot(request: AutopilotStartRequest):
             auto_apply_policy=request.auto_apply_policy,
             auto_apply_patch_types=request.auto_apply_patch_types,
         )
-
         result = controller.get_result(run_id)
-
         return AutopilotStartResponse(
             run_id=run_id,
             status=result.status.value,
@@ -157,314 +130,105 @@ async def start_autopilot(request: AutopilotStartRequest):
             events_url=f"/api/runs/{run_id}/events",
             created_at=datetime.now(timezone.utc).isoformat(),
         )
-
-    except Exception as e:
-        logger.error("Failed to start autopilot run: %s", e)
+    except (FileExistsError, TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to start autopilot run")
         raise HTTPException(
             status_code=500,
-            detail={
-                "error": "autopilot_start_failed",
-                "message": str(e),
-                "details": {},
-            },
-        )
+            detail={"error": "autopilot_start_failed", "message": str(exc), "details": {}},
+        ) from exc
 
 
 @router.get("/{run_id}", response_model=AutopilotStatusResponse)
 async def get_autopilot_status(run_id: str):
-    """Get the status of an autopilot run.
-
-    Args:
-        run_id: The autopilot run identifier.
-
-    Returns:
-        AutopilotStatusResponse with current status, progress, and wisdom apply results.
-    """
-    try:
-        controller = _get_autopilot_controller()
-        result = controller.get_result(run_id)
-
-        # Convert wisdom apply result if present
-        wisdom_result = None
-        if result.wisdom_apply_result:
-            wisdom_result = WisdomApplyResultResponse(
-                patches_processed=result.wisdom_apply_result.patches_processed,
-                patches_applied=result.wisdom_apply_result.patches_applied,
-                patches_rejected=result.wisdom_apply_result.patches_rejected,
-                patches_skipped=result.wisdom_apply_result.patches_skipped,
-                applied_patch_ids=result.wisdom_apply_result.applied_patch_ids,
-            )
-
-        return AutopilotStatusResponse(
-            run_id=run_id,
-            status=result.status.value,
-            current_flow=result.current_flow,
-            flows_completed=result.flows_completed,
-            flows_failed=result.flows_failed,
-            error=result.error,
-            duration_ms=result.duration_ms,
-            wisdom_apply_result=wisdom_result,
-        )
-
-    except Exception as e:
-        logger.error("Failed to get autopilot status: %s", e)
-        raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "autopilot_status_failed",
-                "message": str(e),
-                "details": {},
-            },
-        )
+    _validate_run_id(run_id)
+    return _status_response(_get_autopilot_controller(), run_id)
 
 
 @router.post("/{run_id}/tick", response_model=AutopilotStatusResponse)
 async def tick_autopilot(run_id: str):
-    """Advance an autopilot run by one flow.
-
-    Each tick executes one complete flow in the sequence. Call repeatedly
-    until the run completes.
-
-    Args:
-        run_id: The autopilot run identifier.
-
-    Returns:
-        AutopilotStatusResponse with updated status and wisdom apply results.
-    """
+    _validate_run_id(run_id)
+    controller = _get_autopilot_controller()
     try:
-        controller = _get_autopilot_controller()
         controller.tick(run_id)
-        result = controller.get_result(run_id)
-
-        # Convert wisdom apply result if present
-        wisdom_result = None
-        if result.wisdom_apply_result:
-            wisdom_result = WisdomApplyResultResponse(
-                patches_processed=result.wisdom_apply_result.patches_processed,
-                patches_applied=result.wisdom_apply_result.patches_applied,
-                patches_rejected=result.wisdom_apply_result.patches_rejected,
-                patches_skipped=result.wisdom_apply_result.patches_skipped,
-                applied_patch_ids=result.wisdom_apply_result.applied_patch_ids,
-            )
-
-        return AutopilotStatusResponse(
-            run_id=run_id,
-            status=result.status.value,
-            current_flow=result.current_flow,
-            flows_completed=result.flows_completed,
-            flows_failed=result.flows_failed,
-            error=result.error,
-            duration_ms=result.duration_ms,
-            wisdom_apply_result=wisdom_result,
-        )
-
-    except ValueError as e:
+    except ValueError as exc:
         raise HTTPException(
             status_code=404,
-            detail={
-                "error": "autopilot_not_found",
-                "message": str(e),
-                "details": {"run_id": run_id},
-            },
-        )
-    except Exception as e:
-        logger.error("Failed to tick autopilot: %s", e)
+            detail={"error": "autopilot_not_found", "message": str(exc), "details": {"run_id": run_id}},
+        ) from exc
+    except Exception as exc:
+        logger.exception("Failed to tick autopilot run %s", run_id)
         raise HTTPException(
             status_code=500,
-            detail={
-                "error": "autopilot_tick_failed",
-                "message": str(e),
-                "details": {},
-            },
-        )
+            detail={"error": "autopilot_tick_failed", "message": str(exc), "details": {}},
+        ) from exc
+    return _status_response(controller, run_id)
 
 
 @router.delete("/{run_id}", response_model=RunActionResponse)
 async def cancel_autopilot(run_id: str):
-    """Cancel an autopilot run.
-
-    Terminates the autopilot run and marks it as canceled.
-
-    Args:
-        run_id: The autopilot run identifier.
-
-    Returns:
-        Action response confirming cancellation.
-    """
-    try:
-        controller = _get_autopilot_controller()
-        canceled = controller.cancel(run_id)
-
-        if not canceled:
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "error": "invalid_state",
-                    "message": "Run is already complete or not found",
-                    "details": {"run_id": run_id},
-                },
-            )
-
-        return RunActionResponse(
-            run_id=run_id,
-            status="canceled",
-            message="Autopilot run canceled successfully",
-            timestamp=datetime.now(timezone.utc).isoformat(),
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Failed to cancel autopilot: %s", e)
+    _validate_run_id(run_id)
+    controller = _get_autopilot_controller()
+    if not controller.cancel(run_id):
         raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "autopilot_cancel_failed",
-                "message": str(e),
-                "details": {},
-            },
+            status_code=409,
+            detail={"error": "invalid_state", "message": "Run is complete or unknown", "details": {"run_id": run_id}},
         )
+    return RunActionResponse(
+        run_id=run_id,
+        status="canceled",
+        message="Autopilot run canceled successfully",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
 
 
 @router.post("/{run_id}/stop", response_model=RunActionResponse)
 async def stop_autopilot(run_id: str, request: AutopilotStopRequest):
-    """Stop an autopilot run gracefully with savepoint.
-
-    Unlike cancel, stop creates a clean savepoint that can be resumed.
-    The run will complete its current flow (if any) then stop.
-
-    Args:
-        run_id: The autopilot run identifier.
-        request: Stop request with reason.
-
-    Returns:
-        Action response confirming stop initiation.
-    """
-    try:
-        controller = _get_autopilot_controller()
-        stopped = controller.stop(run_id, reason=request.reason)
-
-        if not stopped:
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "error": "invalid_state",
-                    "message": "Run is already complete or not found",
-                    "details": {"run_id": run_id},
-                },
-            )
-
-        return RunActionResponse(
-            run_id=run_id,
-            status="stopping",
-            message=f"Autopilot run stopping: {request.reason}",
-            timestamp=datetime.now(timezone.utc).isoformat(),
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Failed to stop autopilot: %s", e)
+    _validate_run_id(run_id)
+    controller = _get_autopilot_controller()
+    if not controller.stop(run_id, reason=request.reason):
         raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "autopilot_stop_failed",
-                "message": str(e),
-                "details": {},
-            },
+            status_code=409,
+            detail={"error": "invalid_state", "message": "Run cannot be stopped", "details": {"run_id": run_id}},
         )
+    return RunActionResponse(
+        run_id=run_id,
+        status="stopping",
+        message=f"Autopilot run stopping: {request.reason}",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
 
 
 @router.post("/{run_id}/pause", response_model=RunActionResponse)
 async def pause_autopilot(run_id: str):
-    """Pause an autopilot run at the next flow boundary.
-
-    The run will complete its current flow (if any) then pause.
-    Can be resumed later with the resume endpoint.
-
-    Args:
-        run_id: The autopilot run identifier.
-
-    Returns:
-        Action response confirming pause initiation.
-    """
-    try:
-        controller = _get_autopilot_controller()
-        paused = controller.pause(run_id)
-
-        if not paused:
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "error": "invalid_state",
-                    "message": "Run cannot be paused (already complete, paused, or not found)",
-                    "details": {"run_id": run_id},
-                },
-            )
-
-        return RunActionResponse(
-            run_id=run_id,
-            status="pausing",
-            message="Autopilot run will pause after current flow completes",
-            timestamp=datetime.now(timezone.utc).isoformat(),
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Failed to pause autopilot: %s", e)
+    _validate_run_id(run_id)
+    controller = _get_autopilot_controller()
+    if not controller.pause(run_id):
         raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "autopilot_pause_failed",
-                "message": str(e),
-                "details": {},
-            },
+            status_code=409,
+            detail={"error": "invalid_state", "message": "Run cannot be paused", "details": {"run_id": run_id}},
         )
+    return RunActionResponse(
+        run_id=run_id,
+        status="pausing",
+        message="Autopilot run will pause after the current flow",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )
 
 
 @router.post("/{run_id}/resume", response_model=RunActionResponse)
 async def resume_autopilot(run_id: str):
-    """Resume a paused or stopped autopilot run.
-
-    Continues execution from the saved flow index.
-
-    Args:
-        run_id: The autopilot run identifier.
-
-    Returns:
-        Action response confirming resume.
-    """
-    try:
-        controller = _get_autopilot_controller()
-        resumed = controller.resume(run_id)
-
-        if not resumed:
-            raise HTTPException(
-                status_code=409,
-                detail={
-                    "error": "invalid_state",
-                    "message": "Run cannot be resumed (not paused/stopped or not found)",
-                    "details": {"run_id": run_id},
-                },
-            )
-
-        return RunActionResponse(
-            run_id=run_id,
-            status="running",
-            message="Autopilot run resumed successfully",
-            timestamp=datetime.now(timezone.utc).isoformat(),
-        )
-
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Failed to resume autopilot: %s", e)
+    _validate_run_id(run_id)
+    controller = _get_autopilot_controller()
+    if not controller.resume(run_id):
         raise HTTPException(
-            status_code=500,
-            detail={
-                "error": "autopilot_resume_failed",
-                "message": str(e),
-                "details": {},
-            },
+            status_code=409,
+            detail={"error": "invalid_state", "message": "Run cannot be resumed", "details": {"run_id": run_id}},
         )
+    return RunActionResponse(
+        run_id=run_id,
+        status="running",
+        message="Autopilot run resumed successfully",
+        timestamp=datetime.now(timezone.utc).isoformat(),
+    )

--- a/swarm/api/routes/events.py
+++ b/swarm/api/routes/events.py
@@ -1,10 +1,4 @@
-"""
-SSE event streaming endpoints for Flow Studio API.
-
-Provides Server-Sent Events (SSE) streaming for:
-- Run events (step progress, status changes, logs)
-- Real-time updates during flow execution
-"""
+"""Server-Sent Events as a transport projection of canonical RunEvent rows."""
 
 from __future__ import annotations
 
@@ -18,70 +12,108 @@ from typing import Any, AsyncGenerator, Dict, Optional
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 
-logger = logging.getLogger(__name__)
+from swarm.runtime import storage
+from swarm.runtime.safe_paths import validate_path_component
+from swarm.runtime.types import RunEvent
 
+logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/runs", tags=["events"])
 
 
-# =============================================================================
-# Event Types
-# =============================================================================
-
-
 class EventType:
-    """Standard event types for SSE streaming."""
-
-    # Connection events
     CONNECTED = "connected"
     DISCONNECTED = "disconnected"
     HEARTBEAT = "heartbeat"
 
-    # Run lifecycle events
     RUN_STARTED = "run:started"
     RUN_PAUSED = "run:paused"
-    RUN_PAUSING = "run:pausing"  # Graceful pause initiated (waiting for step)
+    RUN_PAUSING = "run:pausing"
     RUN_RESUMED = "run:resumed"
     RUN_COMPLETED = "run:completed"
     RUN_FAILED = "run:failed"
     RUN_CANCELED = "run:canceled"
     RUN_INTERRUPTED = "run:interrupted"
-    RUN_STOPPING = "run:stopping"  # Graceful stop initiated
-    RUN_STOPPED = "run:stopped"  # Clean stop with savepoint
+    RUN_STOPPING = "run:stopping"
+    RUN_STOPPED = "run:stopped"
 
-    # Flow lifecycle events (for autopilot runs with multiple flows)
-    FLOW_COMPLETED = "flow:completed"  # Individual flow in a multi-flow run
-    PLAN_COMPLETED = "plan:completed"  # Entire plan completed (autopilot run)
+    FLOW_COMPLETED = "flow:completed"
+    PLAN_COMPLETED = "plan:completed"
 
-    # Step events
     STEP_STARTED = "step:started"
     STEP_PROGRESS = "step:progress"
     STEP_COMPLETED = "step:completed"
     STEP_FAILED = "step:failed"
     STEP_SKIPPED = "step:skipped"
 
-    # Artifact events
     ARTIFACT_CREATED = "artifact:created"
     ARTIFACT_UPDATED = "artifact:updated"
 
-    # LLM events
     LLM_STARTED = "llm:started"
     LLM_TOKEN = "llm:token"
     LLM_COMPLETED = "llm:completed"
 
-    # Wisdom events
     WISDOM_PATCH_APPLIED = "wisdom:patch_applied"
     WISDOM_PATCH_REJECTED = "wisdom:patch_rejected"
     WISDOM_PATCH_VALIDATED = "wisdom:patch_validated"
     WISDOM_AUTO_APPLY_STARTED = "wisdom:auto_apply_started"
     WISDOM_AUTO_APPLY_COMPLETED = "wisdom:auto_apply_completed"
 
-    # Error events
     ERROR = "error"
 
 
-# =============================================================================
-# Event Formatting
-# =============================================================================
+_KIND_TO_SSE = {
+    "run_started": EventType.RUN_STARTED,
+    "run_pausing": EventType.RUN_PAUSING,
+    "flow_paused": EventType.RUN_PAUSED,
+    "run_paused": EventType.RUN_PAUSED,
+    "run_resumed": EventType.RUN_RESUMED,
+    "run_completed": EventType.RUN_COMPLETED,
+    "run_failed": EventType.RUN_FAILED,
+    "run_canceled": EventType.RUN_CANCELED,
+    "run_cancelled": EventType.RUN_CANCELED,
+    "run_interrupted": EventType.RUN_INTERRUPTED,
+    "run_stopping": EventType.RUN_STOPPING,
+    "run_stopped": EventType.RUN_STOPPED,
+    "step_start": EventType.STEP_STARTED,
+    "step_started": EventType.STEP_STARTED,
+    "step_progress": EventType.STEP_PROGRESS,
+    "step_end": EventType.STEP_COMPLETED,
+    "step_completed": EventType.STEP_COMPLETED,
+    "step_failed": EventType.STEP_FAILED,
+    "step_skipped": EventType.STEP_SKIPPED,
+    "flow_completed": EventType.FLOW_COMPLETED,
+    "autopilot_flow_completed": EventType.FLOW_COMPLETED,
+    "autopilot_completed": EventType.PLAN_COMPLETED,
+}
+_SSE_TO_KIND = {
+    EventType.RUN_STARTED: "run_started",
+    EventType.RUN_PAUSING: "run_pausing",
+    EventType.RUN_PAUSED: "run_paused",
+    EventType.RUN_RESUMED: "run_resumed",
+    EventType.RUN_COMPLETED: "run_completed",
+    EventType.RUN_FAILED: "run_failed",
+    EventType.RUN_CANCELED: "run_canceled",
+    EventType.RUN_INTERRUPTED: "run_interrupted",
+    EventType.RUN_STOPPING: "run_stopping",
+    EventType.RUN_STOPPED: "run_stopped",
+    EventType.FLOW_COMPLETED: "flow_completed",
+    EventType.PLAN_COMPLETED: "autopilot_completed",
+    EventType.STEP_STARTED: "step_start",
+    EventType.STEP_PROGRESS: "step_progress",
+    EventType.STEP_COMPLETED: "step_end",
+    EventType.STEP_FAILED: "step_failed",
+    EventType.STEP_SKIPPED: "step_skipped",
+}
+_TERMINAL_EVENT_TYPES = frozenset(
+    {
+        EventType.RUN_COMPLETED,
+        EventType.RUN_FAILED,
+        EventType.RUN_CANCELED,
+        EventType.RUN_STOPPED,
+        EventType.PLAN_COMPLETED,
+    }
+)
+_TERMINAL_STATUSES = frozenset({"succeeded", "failed", "canceled", "stopped"})
 
 
 def format_sse_event(
@@ -90,89 +122,62 @@ def format_sse_event(
     event_id: Optional[str] = None,
     retry: Optional[int] = None,
 ) -> str:
-    """Format an SSE event according to the spec.
+    """Format one transport event without mutating its durable source row."""
+    payload = dict(data)
+    payload.setdefault(
+        "timestamp",
+        payload.get("ts") or datetime.now(timezone.utc).isoformat(),
+    )
+    payload.setdefault("type", event_type.replace(":", "_"))
 
-    SSE format:
-        id: <event_id>
-        event: <event_type>
-        retry: <milliseconds>
-        data: <json_data>
-
-    Args:
-        event_type: Event type name.
-        data: Event data (will be JSON serialized).
-        event_id: Optional event ID for resumption.
-        retry: Optional retry interval in milliseconds.
-
-    Returns:
-        Formatted SSE event string.
-    """
     lines = []
-
     if event_id:
         lines.append(f"id: {event_id}")
-
     if event_type:
         lines.append(f"event: {event_type}")
-
     if retry:
         lines.append(f"retry: {retry}")
-
-    # Add timestamp if not present
-    if "timestamp" not in data:
-        data["timestamp"] = datetime.now(timezone.utc).isoformat()
-
-    # Include event type in data for client-side type dispatch
-    # Convert colon-separated format (flow:completed) to underscore format (flow_completed)
-    # for TypeScript compatibility
-    if "type" not in data:
-        data["type"] = event_type.replace(":", "_")
-
-    lines.append(f"data: {json.dumps(data)}")
-    lines.append("")  # Empty line terminates event
-
+    lines.append(f"data: {json.dumps(payload)}")
+    lines.append("")
     return "\n".join(lines) + "\n"
 
 
-# =============================================================================
-# Event Generation
-# =============================================================================
+def _transport_event_type(record: Dict[str, Any]) -> str:
+    kind = record.get("kind")
+    if isinstance(kind, str) and kind:
+        return _KIND_TO_SSE.get(kind, kind)
+
+    legacy_event = record.get("event")
+    if isinstance(legacy_event, str) and legacy_event:
+        return _KIND_TO_SSE.get(legacy_event, legacy_event)
+
+    return "message"
 
 
 async def read_events_file(
     events_file: Path,
     last_position: int = 0,
 ) -> tuple[list[Dict[str, Any]], int]:
-    """Read new events from the events file.
-
-    Args:
-        events_file: Path to events.jsonl file.
-        last_position: Last read position in file.
-
-    Returns:
-        Tuple of (events list, new position).
-    """
-    events = []
-
+    """Read complete JSONL rows after ``last_position``."""
     if not events_file.exists():
-        return events, last_position
+        return [], last_position
 
+    events: list[Dict[str, Any]] = []
+    new_position = last_position
     try:
-        with open(events_file, "r", encoding="utf-8") as f:
-            f.seek(last_position)
-            for line in f:
-                line = line.strip()
-                if line:
-                    try:
-                        event = json.loads(line)
-                        events.append(event)
-                    except json.JSONDecodeError:
-                        logger.warning("Invalid JSON in events file: %s", line)
-            new_position = f.tell()
-    except Exception as e:
-        logger.warning("Error reading events file: %s", e)
-        new_position = last_position
-
+        with events_file.open("r", encoding="utf-8") as stream:
+            stream.seek(last_position)
+            for line in stream:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    events.append(json.loads(stripped))
+                except json.JSONDecodeError:
+                    logger.warning("Invalid JSON in events file: %s", stripped)
+            new_position = stream.tell()
+    except OSError as exc:
+        logger.warning("Error reading events file %s: %s", events_file, exc)
     return events, new_position
 
 
@@ -182,34 +187,17 @@ async def generate_run_events(
     poll_interval: float = 1.0,
     heartbeat_interval: float = 15.0,
 ) -> AsyncGenerator[str, None]:
-    """Generate SSE events for a run.
-
-    Yields SSE-formatted events as they occur:
-    1. Initial connection event
-    2. Events from events.jsonl file (incrementally)
-    3. Heartbeat events (every heartbeat_interval seconds)
-    4. Completion event when run ends
-
-    Args:
-        run_id: Run identifier.
-        runs_root: Root directory for runs.
-        poll_interval: How often to poll for new events.
-        heartbeat_interval: How often to send heartbeat.
-
-    Yields:
-        SSE-formatted event strings.
-    """
+    """Stream canonical journal rows and state-derived heartbeats."""
+    validate_path_component(run_id, "run_id")
     run_dir = runs_root / run_id
     events_file = run_dir / "events.jsonl"
     state_file = run_dir / "run_state.json"
 
-    # Track file position for incremental reading
     last_position = 0
     last_heartbeat = datetime.now(timezone.utc)
-    event_counter = 0
+    event_counter = 1
+    terminal_emitted = False
 
-    # Send connection event
-    event_counter += 1
     yield format_sse_event(
         EventType.CONNECTED,
         {"run_id": run_id, "message": "Connected to event stream"},
@@ -218,158 +206,98 @@ async def generate_run_events(
 
     while True:
         try:
-            # Check if run exists
             if not state_file.exists():
                 yield format_sse_event(
                     EventType.ERROR,
                     {"error": "run_not_found", "message": f"Run '{run_id}' not found"},
                 )
-                break
+                return
 
-            # Read current state
             state = json.loads(state_file.read_text(encoding="utf-8"))
             status = state.get("status", "pending")
+            records, last_position = await read_events_file(events_file, last_position)
 
-            # Read new events from file
-            events, last_position = await read_events_file(events_file, last_position)
-
-            for event in events:
+            for record in records:
                 event_counter += 1
-                event_type = event.pop("event", "message")
+                event_type = _transport_event_type(record)
+                terminal_emitted = terminal_emitted or event_type in _TERMINAL_EVENT_TYPES
+                durable_id = record.get("event_id")
+                yield format_sse_event(
+                    event_type,
+                    record,
+                    event_id=str(durable_id or event_counter),
+                )
 
-                # Transform autopilot events to flow boundary events for frontend
-                if event_type == "autopilot_flow_completed":
-                    # Emit flow:completed for individual flow completion in autopilot
-                    yield format_sse_event(
-                        EventType.FLOW_COMPLETED,
-                        event,
-                        event_id=str(event_counter),
-                    )
-                elif event_type == "autopilot_completed":
-                    # Emit plan:completed when entire autopilot run finishes
-                    yield format_sse_event(
-                        EventType.PLAN_COMPLETED,
-                        event,
-                        event_id=str(event_counter),
-                    )
-                else:
-                    yield format_sse_event(
-                        event_type,
-                        event,
-                        event_id=str(event_counter),
-                    )
-
-            # Send heartbeat if interval elapsed
             now = datetime.now(timezone.utc)
             if (now - last_heartbeat).total_seconds() >= heartbeat_interval:
                 event_counter += 1
+                current_step = (
+                    state.get("current_step_id")
+                    or state.get("current_node")
+                    or state.get("current_step")
+                )
                 yield format_sse_event(
                     EventType.HEARTBEAT,
-                    {
-                        "run_id": run_id,
-                        "status": status,
-                        "current_step": state.get("current_step"),
-                    },
+                    {"run_id": run_id, "status": status, "current_step": current_step},
                     event_id=str(event_counter),
                 )
                 last_heartbeat = now
 
-            # Check for terminal states
-            if status in ("succeeded", "failed", "canceled", "stopped"):
-                event_counter += 1
+            if status in _TERMINAL_STATUSES:
+                if not terminal_emitted:
+                    event_counter += 1
+                    status_to_event = {
+                        "succeeded": EventType.RUN_COMPLETED,
+                        "failed": EventType.RUN_FAILED,
+                        "canceled": EventType.RUN_CANCELED,
+                        "stopped": EventType.RUN_STOPPED,
+                    }
+                    yield format_sse_event(
+                        status_to_event[status],
+                        {
+                            "run_id": run_id,
+                            "status": status,
+                            "completed_at": state.get("completed_at"),
+                            "stopped_at": state.get("stopped_at"),
+                            "error": state.get("error"),
+                            "stop_reason": state.get("stop_reason"),
+                        },
+                        event_id=str(event_counter),
+                    )
+                return
 
-                # Map status to event type
-                status_to_event = {
-                    "succeeded": EventType.RUN_COMPLETED,
-                    "failed": EventType.RUN_FAILED,
-                    "canceled": EventType.RUN_CANCELED,
-                    "stopped": EventType.RUN_STOPPED,
-                }
-
-                yield format_sse_event(
-                    status_to_event[status],
-                    {
-                        "run_id": run_id,
-                        "status": status,
-                        "completed_at": state.get("completed_at"),
-                        "stopped_at": state.get("stopped_at"),
-                        "error": state.get("error"),
-                        "stop_reason": state.get("stop_reason"),
-                    },
-                    event_id=str(event_counter),
-                )
-                break
-
-            # Wait before next poll
             await asyncio.sleep(poll_interval)
-
         except asyncio.CancelledError:
-            # Client disconnected
             logger.debug("SSE client disconnected for run %s", run_id)
-            break
-        except Exception as e:
-            logger.error("Error in event stream for run %s: %s", run_id, e)
+            return
+        except Exception as exc:
+            logger.exception("Error in event stream for run %s", run_id)
             yield format_sse_event(
                 EventType.ERROR,
-                {"error": "stream_error", "message": str(e)},
+                {"error": "stream_error", "message": str(exc)},
             )
-            await asyncio.sleep(5)  # Back off on error
-
-
-# =============================================================================
-# SSE Endpoint
-# =============================================================================
+            await asyncio.sleep(5)
 
 
 @router.get("/{run_id}/events")
 async def stream_run_events(run_id: str, request: Request):
-    """Stream Server-Sent Events for a run.
+    """Stream one run's canonical journal as SSE."""
+    try:
+        validate_path_component(run_id, "run_id")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
-    Provides a real-time event stream for monitoring run progress.
-    Events include step progress, status changes, and artifacts.
-
-    Performs a health tick on SSE connect to keep database status coherent.
-
-    Args:
-        run_id: Run identifier.
-        request: FastAPI request object for disconnect detection.
-
-    Returns:
-        StreamingResponse with SSE content type.
-
-    Example events:
-        event: connected
-        data: {"run_id": "abc123", "message": "Connected to event stream"}
-
-        event: step:started
-        data: {"step_id": "init", "station_id": "repo-operator"}
-
-        event: step:completed
-        data: {"step_id": "init", "status": "VERIFIED"}
-
-        event: heartbeat
-        data: {"run_id": "abc123", "status": "running"}
-
-        event: run:completed
-        data: {"run_id": "abc123", "status": "succeeded"}
-    """
-    # Get runs root from spec manager
     from ..server import get_spec_manager
 
-    manager = get_spec_manager()
-    runs_root = manager.runs_root
-
-    # Health tick on SSE connect to keep DB status coherent
+    runs_root = get_spec_manager().runs_root
     try:
         from swarm.runtime.resilient_db import check_db_health
 
         check_db_health()
-    except Exception as e:
-        logger.warning("DB health check failed on SSE connect: %s", e)
+    except Exception as exc:
+        logger.warning("DB health check failed on SSE connect: %s", exc)
 
-    # Verify run exists
-    run_dir = runs_root / run_id
-    if not run_dir.exists():
+    if not (runs_root / run_id).is_dir():
         raise HTTPException(
             status_code=404,
             detail={
@@ -381,9 +309,8 @@ async def stream_run_events(run_id: str, request: Request):
 
     async def event_stream():
         async for event in generate_run_events(run_id, runs_root):
-            # Check if client disconnected
             if await request.is_disconnected():
-                break
+                return
             yield event
 
     return StreamingResponse(
@@ -392,14 +319,39 @@ async def stream_run_events(run_id: str, request: Request):
         headers={
             "Cache-Control": "no-cache",
             "Connection": "keep-alive",
-            "X-Accel-Buffering": "no",  # Disable nginx buffering
+            "X-Accel-Buffering": "no",
         },
     )
 
 
-# =============================================================================
-# Event Writing Utilities
-# =============================================================================
+def _canonical_event_from_transport(
+    run_id: str,
+    event_type: str,
+    data: Dict[str, Any],
+) -> RunEvent:
+    payload = dict(data)
+    payload.pop("run_id", None)
+    flow_key = str(payload.pop("flow_key", ""))
+    step_id = payload.pop("step_id", None)
+    agent_key = payload.pop("agent_key", None)
+    payload.pop("event", None)
+    payload.pop("kind", None)
+    payload.pop("event_id", None)
+    payload.pop("seq", None)
+    payload.pop("ts", None)
+    payload.pop("timestamp", None)
+    payload.pop("type", None)
+
+    kind = _SSE_TO_KIND.get(event_type, event_type.replace(":", "_"))
+    return RunEvent(
+        run_id=run_id,
+        ts=datetime.now(timezone.utc),
+        kind=kind,
+        flow_key=flow_key,
+        step_id=step_id,
+        agent_key=agent_key,
+        payload=payload,
+    )
 
 
 async def write_event(
@@ -408,25 +360,13 @@ async def write_event(
     event_type: str,
     data: Dict[str, Any],
 ) -> None:
-    """Write an event to a run's events file.
-
-    Args:
-        run_id: Run identifier.
-        runs_root: Root directory for runs.
-        event_type: Event type name.
-        data: Event data.
-    """
-    events_file = runs_root / run_id / "events.jsonl"
-    events_file.parent.mkdir(parents=True, exist_ok=True)
-
-    event = {
-        "event": event_type,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        **data,
-    }
-
-    with open(events_file, "a", encoding="utf-8") as f:
-        f.write(json.dumps(event) + "\n")
+    """Compatibility writer that persists a canonical RunEvent row."""
+    validate_path_component(run_id, "run_id")
+    storage.append_event(
+        run_id,
+        _canonical_event_from_transport(run_id, event_type, data),
+        runs_root,
+    )
 
 
 def write_event_sync(
@@ -435,22 +375,10 @@ def write_event_sync(
     event_type: str,
     data: Dict[str, Any],
 ) -> None:
-    """Synchronous version of write_event.
-
-    Args:
-        run_id: Run identifier.
-        runs_root: Root directory for runs.
-        event_type: Event type name.
-        data: Event data.
-    """
-    events_file = runs_root / run_id / "events.jsonl"
-    events_file.parent.mkdir(parents=True, exist_ok=True)
-
-    event = {
-        "event": event_type,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        **data,
-    }
-
-    with open(events_file, "a", encoding="utf-8") as f:
-        f.write(json.dumps(event) + "\n")
+    """Synchronous compatibility writer for control endpoints."""
+    validate_path_component(run_id, "run_id")
+    storage.append_event(
+        run_id,
+        _canonical_event_from_transport(run_id, event_type, data),
+        runs_root,
+    )

--- a/swarm/api/routes/issue_routes.py
+++ b/swarm/api/routes/issue_routes.py
@@ -1,9 +1,4 @@
-"""
-Issue ingestion endpoints for Flow Studio API.
-
-Provides REST endpoints for:
-- Creating runs from issue references (GitHub, GitLab, etc.)
-"""
+"""Create one canonical Flow Studio run from an issue snapshot."""
 
 from __future__ import annotations
 
@@ -11,6 +6,7 @@ import json
 import logging
 import re
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
@@ -21,34 +17,22 @@ from swarm.runtime.safe_paths import validate_path_component
 from ..services.run_state import get_state_manager
 
 logger = logging.getLogger(__name__)
-
 router = APIRouter(tags=["issues"])
 
 
-# =============================================================================
-# Pydantic Models
-# =============================================================================
-
-
 class IssueIngestionRequest(BaseModel):
-    """Request to start a run from an issue."""
-
-    provider: str = Field("github", description="Issue provider (github, gitlab, etc.)")
-    repo: Optional[str] = Field(None, description="Repository in 'owner/repo' format")
-    issue_number: Optional[int] = Field(None, description="Issue number")
-    issue_url: Optional[str] = Field(
-        None, description="Full issue URL (alternative to repo+number)"
-    )
-    title: Optional[str] = Field(None, description="Issue title (if not fetching)")
-    body: Optional[str] = Field(None, description="Issue body (if not fetching)")
-    labels: Optional[List[str]] = Field(None, description="Issue labels")
-    start_autopilot: bool = Field(False, description="Start autopilot run after ingestion")
-    flow_keys: Optional[List[str]] = Field(None, description="Flows to execute (defaults to all)")
+    provider: str = Field("github", description="Issue provider")
+    repo: Optional[str] = Field(None, description="Repository as owner/repo")
+    issue_number: Optional[int] = None
+    issue_url: Optional[str] = None
+    title: Optional[str] = None
+    body: Optional[str] = None
+    labels: Optional[List[str]] = None
+    start_autopilot: bool = False
+    flow_keys: Optional[List[str]] = None
 
 
 class IssueIngestionResponse(BaseModel):
-    """Response from issue ingestion."""
-
     run_id: str
     status: str
     issue_snapshot_path: str
@@ -58,8 +42,6 @@ class IssueIngestionResponse(BaseModel):
 
 
 class IssueSnapshot(BaseModel):
-    """Snapshot of an issue for Flow 1 input."""
-
     provider: str
     repo: str
     issue_number: int
@@ -71,74 +53,33 @@ class IssueSnapshot(BaseModel):
     source_metadata: Dict[str, Any] = Field(default_factory=dict)
 
 
-# =============================================================================
-# Helpers
-# =============================================================================
-
-
 def _parse_issue_url(url: str) -> tuple[str, str, int]:
-    """Parse an issue URL into provider, repo, and number.
+    github_match = re.match(r"https?://github\.com/([^/]+/[^/]+)/issues/(\d+)", url)
+    if github_match:
+        return "github", github_match.group(1), int(github_match.group(2))
 
-    Args:
-        url: Issue URL (e.g., 'https://github.com/owner/repo/issues/123')
-
-    Returns:
-        Tuple of (provider, repo, issue_number)
-
-    Raises:
-        ValueError: If URL format is not recognized.
-    """
-    # GitHub: https://github.com/owner/repo/issues/123
-    gh_match = re.match(r"https?://github\.com/([^/]+/[^/]+)/issues/(\d+)", url)
-    if gh_match:
-        return "github", gh_match.group(1), int(gh_match.group(2))
-
-    # GitLab: https://gitlab.com/owner/repo/-/issues/123
-    gl_match = re.match(r"https?://gitlab\.com/([^/]+/[^/]+)/-/issues/(\d+)", url)
-    if gl_match:
-        return "gitlab", gl_match.group(1), int(gl_match.group(2))
+    gitlab_match = re.match(r"https?://gitlab\.com/([^/]+/[^/]+)/-/issues/(\d+)", url)
+    if gitlab_match:
+        return "gitlab", gitlab_match.group(1), int(gitlab_match.group(2))
 
     raise ValueError(f"Unrecognized issue URL format: {url}")
 
 
 def _get_autopilot_controller():
-    """Get or create the global autopilot controller."""
-
-    # Import from autopilot_routes to share the same controller instance
     from .autopilot_routes import _get_autopilot_controller as get_controller
 
     return get_controller()
 
 
-# =============================================================================
-# Issue Ingestion Endpoints
-# =============================================================================
+def _issue_run_id(repo: Optional[str], issue_number: Optional[int], now: datetime) -> str:
+    repo_component = (repo or "local/manual").replace("/", "-")
+    return f"issue-{repo_component}-{issue_number or 0}-{now.strftime('%Y%m%d%H%M%S')}"
 
 
 @router.post("/from-issue", response_model=IssueIngestionResponse, status_code=201)
 async def ingest_issue(request: IssueIngestionRequest):
-    """Create a run from an issue reference.
-
-    Writes an issue snapshot to the run's signal/ directory as the canonical
-    input artifact for Flow 1 (Signal). Optionally starts an autopilot run.
-
-    The issue can be specified by:
-    - repo + issue_number: e.g., "owner/repo" and 123
-    - issue_url: e.g., "https://github.com/owner/repo/issues/123"
-    - title + body: Manual issue data (no fetching)
-
-    Args:
-        request: Issue ingestion request.
-
-    Returns:
-        IssueIngestionResponse with run_id and snapshot path.
-
-    Raises:
-        400: Invalid issue reference.
-        500: Ingestion failed.
-    """
+    """Snapshot an issue and optionally start autopilot under the same run ID."""
     try:
-        # Determine issue details
         provider = request.provider
         repo = request.repo
         issue_number = request.issue_number
@@ -146,29 +87,32 @@ async def ingest_issue(request: IssueIngestionRequest):
         if request.issue_url:
             try:
                 provider, repo, issue_number = _parse_issue_url(request.issue_url)
-            except ValueError as e:
+            except ValueError as exc:
                 raise HTTPException(
                     status_code=400,
                     detail={
                         "error": "invalid_url",
-                        "message": str(e),
+                        "message": str(exc),
                         "details": {"url": request.issue_url},
                     },
-                )
+                ) from exc
 
-        if not repo or issue_number is None:
-            if not request.title:
-                raise HTTPException(
-                    status_code=400,
-                    detail={
-                        "error": "missing_reference",
-                        "message": "Must provide repo+issue_number, issue_url, or title+body",
-                        "details": {},
-                    },
-                )
+        if (not repo or issue_number is None) and not request.title:
+            raise HTTPException(
+                status_code=400,
+                detail={
+                    "error": "missing_reference",
+                    "message": "Provide repo+issue_number, issue_url, or title+body",
+                    "details": {},
+                },
+            )
 
-        # Create issue snapshot
         now = datetime.now(timezone.utc)
+        issue_ref = f"{repo}#{issue_number}" if repo and issue_number is not None else None
+        issue_url = request.issue_url
+        if not issue_url and provider == "github" and repo and issue_number is not None:
+            issue_url = f"https://github.com/{repo}/issues/{issue_number}"
+
         snapshot = IssueSnapshot(
             provider=provider,
             repo=repo or "local/manual",
@@ -176,97 +120,100 @@ async def ingest_issue(request: IssueIngestionRequest):
             title=request.title or f"Issue #{issue_number}",
             body=request.body or "",
             labels=request.labels or [],
-            url=request.issue_url
-            or (
-                f"https://github.com/{repo}/issues/{issue_number}"
-                if provider == "github" and repo and issue_number
-                else None
-            ),
+            url=issue_url,
             fetched_at=now.isoformat(),
-            source_metadata={
-                "ingested_via": "api",
-                "provider": provider,
-            },
+            source_metadata={"ingested_via": "api", "provider": provider},
         )
 
-        # Generate run ID
-        run_id = f"issue-{repo.replace('/', '-') if repo else 'manual'}-{issue_number or 0}-{now.strftime('%Y%m%d%H%M%S')}"
-
-        # Validate run_id before file system operations
+        run_id = _issue_run_id(repo, issue_number, now)
         try:
             validate_path_component(run_id, "generated run_id")
-        except ValueError as e:
+        except ValueError as exc:
             raise HTTPException(
                 status_code=400,
                 detail={
                     "error": "invalid_run_id",
-                    "message": f"Generated run ID is invalid: {str(e)}",
+                    "message": f"Generated run ID is invalid: {exc}",
                     "details": {"run_id": run_id},
                 },
+            ) from exc
+
+        state_manager = get_state_manager()
+        snapshot_relative = Path("signal") / "issue_snapshot.json"
+        context = {
+            "issue_ref": issue_ref or "manual",
+            "issue_snapshot_path": snapshot_relative.as_posix(),
+        }
+
+        autopilot_started = False
+        if request.start_autopilot:
+            controller = _get_autopilot_controller()
+            started_run_id = controller.start(
+                run_id=run_id,
+                issue_ref=issue_ref,
+                flow_keys=request.flow_keys,
+                initiator="api:issue",
+                params={"issue_snapshot_path": snapshot_relative.as_posix()},
+            )
+            if started_run_id != run_id:
+                raise RuntimeError(
+                    f"Autopilot changed canonical run identity: {run_id} -> {started_run_id}"
+                )
+            autopilot_started = True
+
+            # Test doubles and compatibility controllers may not yet initialize
+            # the durable state. Real canonical autopilot already has.
+            try:
+                await state_manager.get_run(run_id)
+            except FileNotFoundError:
+                await state_manager.create_run(
+                    flow_id=(request.flow_keys or ["signal"])[0],
+                    run_id=run_id,
+                    context=context,
+                    mode="execute",
+                    initiator="api:issue",
+                )
+        else:
+            await state_manager.create_run(
+                flow_id="signal",
+                run_id=run_id,
+                context=context,
+                mode="execute",
+                initiator="api:issue",
             )
 
-        # Create run directory structure
-        state_manager = get_state_manager()
         run_dir = state_manager.runs_root / run_id
         signal_dir = run_dir / "signal"
         signal_dir.mkdir(parents=True, exist_ok=True)
 
-        # Write issue snapshot
         snapshot_path = signal_dir / "issue_snapshot.json"
         snapshot_path.write_text(
             json.dumps(snapshot.model_dump(), indent=2),
             encoding="utf-8",
         )
-
-        # Also write as markdown for human readability
-        issue_md_path = signal_dir / "issue.md"
-        issue_md_path.write_text(
+        (signal_dir / "issue.md").write_text(
             f"# {snapshot.title}\n\n"
             f"**Source:** {snapshot.url or 'Manual input'}\n"
             f"**Labels:** {', '.join(snapshot.labels) if snapshot.labels else 'None'}\n\n"
-            f"---\n\n"
-            f"{snapshot.body}\n",
+            f"---\n\n{snapshot.body}\n",
             encoding="utf-8",
         )
-
-        # Create initial run state
-        await state_manager.create_run(
-            flow_id="signal",
-            run_id=run_id,
-            context={
-                "issue_ref": f"{repo}#{issue_number}" if repo else "manual",
-                "issue_snapshot_path": str(snapshot_path.relative_to(run_dir)),
-            },
-        )
-
-        # Optionally start autopilot
-        autopilot_started = False
-        if request.start_autopilot:
-            controller = _get_autopilot_controller()
-            controller.start(
-                issue_ref=f"{repo}#{issue_number}" if repo else None,
-                flow_keys=request.flow_keys,
-            )
-            autopilot_started = True
 
         return IssueIngestionResponse(
             run_id=run_id,
             status="created",
-            issue_snapshot_path=str(snapshot_path.relative_to(run_dir)),
+            issue_snapshot_path=snapshot_relative.as_posix(),
             autopilot_started=autopilot_started,
             events_url=f"/api/runs/{run_id}/events",
             created_at=now.isoformat(),
         )
-
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error("Failed to ingest issue: %s", e)
+    except FileExistsError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as exc:
+        logger.exception("Failed to ingest issue")
         raise HTTPException(
             status_code=500,
-            detail={
-                "error": "ingestion_failed",
-                "message": str(e),
-                "details": {},
-            },
-        )
+            detail={"error": "ingestion_failed", "message": str(exc), "details": {}},
+        ) from exc

--- a/swarm/api/routes/runs_crud.py
+++ b/swarm/api/routes/runs_crud.py
@@ -1,11 +1,4 @@
-"""
-Run CRUD endpoints for Flow Studio API.
-
-Provides REST endpoints for:
-- Starting new runs (POST /)
-- Listing runs (GET /)
-- Getting run state (GET /{run_id})
-"""
+"""Run creation and read endpoints for the canonical run service."""
 
 from __future__ import annotations
 
@@ -16,74 +9,80 @@ from fastapi import APIRouter, Header, HTTPException, Response
 from fastapi.responses import JSONResponse
 
 from ..services.run_state import get_state_manager
-from .runs_models import (
-    RunListResponse,
-    RunStartRequest,
-    RunStartResponse,
-    RunSummary,
-)
+from .runs_models import RunListResponse, RunStartRequest, RunStartResponse, RunSummary
 
 logger = logging.getLogger(__name__)
-
 router = APIRouter(tags=["runs"])
+_VALID_MODES = frozenset({"execute", "preview", "validate"})
 
 
 @router.post("", response_model=RunStartResponse, status_code=201)
 async def start_run(request: RunStartRequest):
-    """Start a new run.
+    """Create one complete durable run record under the returned identity."""
+    if request.mode not in _VALID_MODES:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_mode",
+                "message": f"Unsupported run mode '{request.mode}'",
+                "details": {"valid_modes": sorted(_VALID_MODES)},
+            },
+        )
 
-    Creates a new run directory and initializes run state.
-    Returns the run ID and SSE events URL.
-
-    Args:
-        request: Run start request with flow_id and optional parameters.
-
-    Returns:
-        RunStartResponse with run_id and events_url.
-    """
     state_manager = get_state_manager()
-
     try:
         state = await state_manager.create_run(
             flow_id=request.flow_id,
             run_id=request.run_id,
             context=request.context,
             start_step=request.start_step,
+            mode=request.mode,
+            backend=request.backend,
+            initiator="api",
         )
-
-        return RunStartResponse(
-            run_id=state["run_id"],
-            flow_id=state["flow_id"],
-            status=state["status"],
-            created_at=state["created_at"],
-            events_url=f"/api/runs/{state['run_id']}/events",
-        )
-
-    except Exception as e:
-        logger.error("Failed to start run: %s", e)
+    except FileExistsError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "run_exists",
+                "message": str(exc),
+                "details": {"run_id": request.run_id},
+            },
+        ) from exc
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "invalid_run_request",
+                "message": str(exc),
+                "details": {},
+            },
+        ) from exc
+    except Exception as exc:
+        logger.exception("Failed to initialize run")
         raise HTTPException(
             status_code=500,
             detail={
                 "error": "run_start_failed",
-                "message": str(e),
+                "message": str(exc),
                 "details": {},
             },
-        )
+        ) from exc
+
+    return RunStartResponse(
+        run_id=state["run_id"],
+        flow_id=state["flow_id"],
+        status=state["status"],
+        created_at=state["created_at"],
+        events_url=f"/api/runs/{state['run_id']}/events",
+    )
 
 
 @router.get("", response_model=RunListResponse)
 async def list_runs(limit: int = 20):
-    """List recent runs.
-
-    Args:
-        limit: Maximum number of runs to return.
-
-    Returns:
-        List of run summaries.
-    """
     state_manager = get_state_manager()
     runs = state_manager.list_runs(limit=limit)
-    return RunListResponse(runs=[RunSummary(**r) for r in runs])
+    return RunListResponse(runs=[RunSummary(**run) for run in runs])
 
 
 @router.get("/{run_id}")
@@ -91,34 +90,10 @@ async def get_run(
     run_id: str,
     if_none_match: Optional[str] = Header(None, alias="If-None-Match"),
 ):
-    """Get run state.
-
-    Args:
-        run_id: Run identifier.
-        if_none_match: Optional ETag for caching.
-
-    Returns:
-        Run state with ETag header.
-
-    Raises:
-        404: Run not found.
-        304: Not modified (if ETag matches).
-    """
     state_manager = get_state_manager()
-
     try:
         state, etag = await state_manager.get_run(run_id)
-
-        # Check If-None-Match for caching
-        if if_none_match and if_none_match.strip('"') == etag:
-            return Response(status_code=304)
-
-        return JSONResponse(
-            content=state,
-            headers={"ETag": f'"{etag}"'},
-        )
-
-    except FileNotFoundError:
+    except FileNotFoundError as exc:
         raise HTTPException(
             status_code=404,
             detail={
@@ -126,4 +101,9 @@ async def get_run(
                 "message": f"Run '{run_id}' not found",
                 "details": {"run_id": run_id},
             },
-        )
+        ) from exc
+
+    if if_none_match and if_none_match.strip('"') == etag:
+        return Response(status_code=304)
+
+    return JSONResponse(content=state, headers={"ETag": f'"{etag}"'})

--- a/swarm/api/routes/runs_models.py
+++ b/swarm/api/routes/runs_models.py
@@ -1,8 +1,4 @@
-"""
-Pydantic models for run control endpoints.
-
-Shared models used across runs_crud, runs_control, and runs_stack modules.
-"""
+"""Pydantic models for run creation, control, and inspection endpoints."""
 
 from __future__ import annotations
 
@@ -10,24 +6,22 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
-# =============================================================================
-# Request Models
-# =============================================================================
-
 
 class RunStartRequest(BaseModel):
-    """Request to start a new run."""
+    """Request to create a run and, in execute mode, schedule its backend."""
 
     flow_id: str = Field(..., description="Flow to execute")
-    run_id: Optional[str] = Field(None, description="Custom run ID (generated if not provided)")
+    run_id: Optional[str] = Field(None, description="Custom run ID (generated if omitted)")
     context: Optional[Dict[str, Any]] = Field(None, description="Initial context for the run")
-    start_step: Optional[str] = Field(None, description="Step to start from (defaults to first)")
+    start_step: Optional[str] = Field(None, description="Initial node (defaults to graph entry)")
     mode: str = Field("execute", description="Execution mode: execute, preview, validate")
+    backend: str = Field(
+        "claude-step-orchestrator",
+        description="Backend selected for execution",
+    )
 
 
 class InjectRequest(BaseModel):
-    """Request to inject a node into a run."""
-
     step_id: str = Field(..., description="ID for the injected step")
     station_id: str = Field(..., description="Station to use for the step")
     position: str = Field(
@@ -37,45 +31,30 @@ class InjectRequest(BaseModel):
 
 
 class InterruptRequest(BaseModel):
-    """Request to interrupt a run with a detour."""
-
     detour_flow: Optional[str] = Field(None, description="Flow to execute as detour")
     detour_steps: Optional[List[str]] = Field(
         None, description="Specific steps to execute as detour"
     )
     reason: str = Field(..., description="Reason for the interrupt")
-    resume_after: bool = Field(True, description="Whether to resume original flow after detour")
+    resume_after: bool = Field(True, description="Resume the original graph after detour")
 
 
 class PauseRequest(BaseModel):
-    """Request to pause a run."""
-
     wait_for_step: bool = Field(
-        True, description="Wait for current step to complete before pausing"
+        True, description="Wait for the current step transaction before pausing"
     )
 
 
 class ResumeRequest(BaseModel):
-    """Request to resume a paused or stopped run."""
-
-    from_step: Optional[str] = Field(None, description="Step to resume from (defaults to saved PC)")
+    from_step: Optional[str] = Field(None, description="Optional explicit resume node")
 
 
 class StopRequest(BaseModel):
-    """Request to stop a run gracefully."""
-
     reason: str = Field("user_initiated", description="Reason for stopping")
-    drain_timeout_ms: int = Field(30000, description="Timeout for draining messages in ms")
-
-
-# =============================================================================
-# Response Models
-# =============================================================================
+    drain_timeout_ms: int = Field(30000, description="Message-drain timeout in milliseconds")
 
 
 class RunStartResponse(BaseModel):
-    """Response when starting a new run."""
-
     run_id: str
     flow_id: str
     status: str
@@ -84,8 +63,6 @@ class RunStartResponse(BaseModel):
 
 
 class RunSummary(BaseModel):
-    """Run summary for list endpoint."""
-
     run_id: str
     flow_key: Optional[str] = None
     status: Optional[str] = None
@@ -93,13 +70,11 @@ class RunSummary(BaseModel):
 
 
 class RunListResponse(BaseModel):
-    """Response for list runs endpoint."""
-
     runs: List[RunSummary]
 
 
 class RunState(BaseModel):
-    """Full run state."""
+    """Compatibility projection of the canonical runtime RunState."""
 
     run_id: str
     flow_id: str
@@ -116,8 +91,6 @@ class RunState(BaseModel):
 
 
 class RunActionResponse(BaseModel):
-    """Generic response for run actions."""
-
     run_id: str
     status: str
     message: str
@@ -125,8 +98,6 @@ class RunActionResponse(BaseModel):
 
 
 class StopReportInfo(BaseModel):
-    """Information included in stop report."""
-
     last_step_id: Optional[str] = None
     last_routing_intent: Optional[str] = None
     last_tool_calls: List[str] = Field(default_factory=list)
@@ -136,8 +107,6 @@ class StopReportInfo(BaseModel):
 
 
 class StopResponse(BaseModel):
-    """Response when stopping a run."""
-
     run_id: str
     status: str
     message: str
@@ -147,8 +116,6 @@ class StopResponse(BaseModel):
 
 
 class InterruptionFrameResponse(BaseModel):
-    """A single frame in the interruption stack."""
-
     frame_id: str
     interrupted_flow: Optional[str] = None
     interrupted_step: Optional[str] = None
@@ -162,8 +129,6 @@ class InterruptionFrameResponse(BaseModel):
 
 
 class InterruptionStackResponse(BaseModel):
-    """Response for the interruption stack endpoint."""
-
     run_id: str
     stack_depth: int
     frames: List[InterruptionFrameResponse]

--- a/swarm/api/services/run_state.py
+++ b/swarm/api/services/run_state.py
@@ -1,8 +1,9 @@
-"""
-Run state management service.
+"""API adapter over the canonical runtime run state.
 
-Extracted from routes/runs.py to separate state management logic from HTTP endpoints.
-Provides in-memory cache with disk persistence for run state.
+``swarm.runtime.types.RunState`` and ``run_state.json`` own the durable program
+counter.  This service supplies the older HTTP field names as a compatibility
+projection; it does not maintain a second state authority or cache stale state
+across executor writes.
 """
 
 from __future__ import annotations
@@ -17,36 +18,73 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from swarm.runtime.run_factory import initialize_run
 from swarm.runtime.safe_paths import validate_path_component
+from swarm.runtime.types import RunSpec
 
 logger = logging.getLogger(__name__)
 
 
 class RunStateManager:
-    """Manages run state in memory and on disk.
-
-    In-memory cache for fast access, with disk persistence for durability.
-    """
+    """Read and mutate the canonical run state through an HTTP projection."""
 
     def __init__(self, runs_root: Path):
         self.runs_root = runs_root
+        # Retained for source compatibility only. Reads always come from disk so
+        # executor updates cannot be hidden by an API-process cache.
         self._cache: Dict[str, Dict[str, Any]] = {}
         self._locks: Dict[str, asyncio.Lock] = {}
 
     def _get_lock(self, run_id: str) -> asyncio.Lock:
-        """Get or create a lock for a run."""
         if run_id not in self._locks:
             self._locks[run_id] = asyncio.Lock()
         return self._locks[run_id]
 
     def _compute_etag(self, state: Dict[str, Any]) -> str:
-        """Compute ETag from state."""
         content = json.dumps(state, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(content.encode()).hexdigest()[:16]
 
     def _state_path(self, run_id: str) -> Path:
-        """Get path to run state file."""
         return self.runs_root / run_id / "run_state.json"
+
+    @staticmethod
+    def _synchronize_aliases(state: Dict[str, Any]) -> Dict[str, Any]:
+        """Keep legacy HTTP names synchronized with runtime-owned fields."""
+        flow_key = state.get("flow_key") or state.get("flow_id") or ""
+        state["flow_key"] = flow_key
+        state["flow_id"] = flow_key
+
+        current_step = (
+            state.get("current_step_id")
+            or state.get("current_node")
+            or state.get("current_step")
+        )
+        state["current_step_id"] = current_step
+        state["current_node"] = current_step
+        state["current_step"] = current_step
+
+        completed = list(state.get("completed_nodes") or state.get("completed_steps") or [])
+        state["completed_nodes"] = completed
+        state["completed_steps"] = list(completed)
+
+        state.setdefault("pending_steps", [])
+        state.setdefault("context", {})
+        state.setdefault("paused_at", None)
+        state.setdefault("completed_at", None)
+        state.setdefault("error", None)
+
+        timestamp = state.get("timestamp") or datetime.now(timezone.utc).isoformat()
+        state["timestamp"] = timestamp
+        state.setdefault("created_at", timestamp)
+        state.setdefault("updated_at", timestamp)
+        return state
+
+    def _load_state(self, run_id: str) -> Dict[str, Any]:
+        state_path = self._state_path(run_id)
+        if not state_path.exists():
+            raise FileNotFoundError(f"Run '{run_id}' not found")
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        return self._synchronize_aliases(state)
 
     async def create_run(
         self,
@@ -54,60 +92,65 @@ class RunStateManager:
         run_id: Optional[str] = None,
         context: Optional[Dict[str, Any]] = None,
         start_step: Optional[str] = None,
+        *,
+        mode: str = "execute",
+        backend: str = "claude-step-orchestrator",
+        initiator: str = "api",
     ) -> Dict[str, Any]:
-        """Create a new run."""
+        """Create one complete constitutional run record."""
         validate_path_component(flow_id, "flow_id")
         if run_id:
             validate_path_component(run_id, "run_id")
+        else:
+            run_id = (
+                f"{flow_id}-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-"
+                f"{uuid.uuid4().hex[:8]}"
+            )
 
-        if run_id is None:
-            # Note: generated run_id is safe by construction (alphanumeric + hyphens)
-            run_id = f"{flow_id}-{datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')}-{uuid.uuid4().hex[:8]}"
+        spec = RunSpec(
+            flow_keys=[flow_id],
+            backend=backend,
+            initiator=initiator,
+            params={
+                "mode": mode,
+                "initial_context": dict(context or {}),
+                "start_step": start_step,
+            },
+        )
+        initialized = initialize_run(
+            run_id,
+            spec,
+            flow_key=flow_id,
+            start_step=start_step,
+            mode=mode,
+            runs_dir=self.runs_root,
+        )
 
-        now = datetime.now(timezone.utc).isoformat()
-
-        state = {
-            "run_id": run_id,
-            "flow_id": flow_id,
-            "status": "pending",
-            "current_step": start_step,
-            "completed_steps": [],
-            "pending_steps": [],
-            "context": context or {},
-            "created_at": now,
-            "updated_at": now,
-            "paused_at": None,
-            "completed_at": None,
-            "error": None,
-        }
-
-        # Create run directory
-        run_dir = self.runs_root / run_id
-        run_dir.mkdir(parents=True, exist_ok=True)
-
-        # Save state
+        state = json.loads(
+            (initialized.path / "run_state.json").read_text(encoding="utf-8")
+        )
+        now = initialized.summary.created_at.isoformat()
+        state.update(
+            {
+                "current_step": start_step,
+                "completed_steps": [],
+                "pending_steps": [],
+                "context": dict(context or {}),
+                "created_at": now,
+                "updated_at": now,
+                "paused_at": None,
+                "completed_at": None,
+                "error": None,
+            }
+        )
         await self._save_state(run_id, state)
-
-        return state
+        return self._synchronize_aliases(state)
 
     def _get_run_unlocked(self, run_id: str) -> tuple[Dict[str, Any], str]:
-        """Get run state without locking (internal use only)."""
-        # Check cache first
-        if run_id in self._cache:
-            state = self._cache[run_id]
-            return state, self._compute_etag(state)
-
-        # Load from disk
-        state_path = self._state_path(run_id)
-        if not state_path.exists():
-            raise FileNotFoundError(f"Run '{run_id}' not found")
-
-        state = json.loads(state_path.read_text(encoding="utf-8"))
-        self._cache[run_id] = state
+        state = self._load_state(run_id)
         return state, self._compute_etag(state)
 
     async def get_run(self, run_id: str) -> tuple[Dict[str, Any], str]:
-        """Get run state with ETag."""
         validate_path_component(run_id, "run_id")
         async with self._get_lock(run_id):
             return self._get_run_unlocked(run_id)
@@ -118,90 +161,90 @@ class RunStateManager:
         updates: Dict[str, Any],
         expected_etag: Optional[str] = None,
     ) -> tuple[Dict[str, Any], str]:
-        """Update run state with optional ETag check."""
+        """Update canonical state while preserving runtime/API aliases."""
         validate_path_component(run_id, "run_id")
         async with self._get_lock(run_id):
             state, current_etag = self._get_run_unlocked(run_id)
-
             if expected_etag and expected_etag != current_etag:
                 raise ValueError(f"ETag mismatch: expected {expected_etag}, got {current_etag}")
 
-            # Apply updates
             state.update(updates)
-            state["updated_at"] = datetime.now(timezone.utc).isoformat()
+            now = datetime.now(timezone.utc).isoformat()
+            state["updated_at"] = now
+            state["timestamp"] = now
+
+            if "current_step" in updates:
+                state["current_step_id"] = updates["current_step"]
+                state["current_node"] = updates["current_step"]
+            elif "current_step_id" in updates:
+                state["current_step"] = updates["current_step_id"]
+                state["current_node"] = updates["current_step_id"]
+
+            if "completed_steps" in updates:
+                state["completed_nodes"] = list(updates["completed_steps"])
+            elif "completed_nodes" in updates:
+                state["completed_steps"] = list(updates["completed_nodes"])
+
+            if "flow_id" in updates:
+                state["flow_key"] = updates["flow_id"]
+            elif "flow_key" in updates:
+                state["flow_id"] = updates["flow_key"]
 
             await self._save_state(run_id, state)
-            return state, self._compute_etag(state)
+            projected = self._synchronize_aliases(state)
+            return projected, self._compute_etag(projected)
 
     async def _save_state(self, run_id: str, state: Dict[str, Any]) -> None:
-        """Save state to disk and cache."""
+        state = self._synchronize_aliases(state)
         state_path = self._state_path(run_id)
         state_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Write atomically
         tmp_path = state_path.with_suffix(".tmp")
         tmp_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
         os.replace(tmp_path, state_path)
-
-        self._cache[run_id] = state
+        self._cache[run_id] = dict(state)
 
     def list_runs(self, limit: int = 20) -> List[Dict[str, Any]]:
-        """List recent runs.
-
-        Uses os.scandir for efficient directory traversal.
-        Optimized to sort by mtime BEFORE checking file existence,
-        reducing I/O overhead (stat calls) for large run histories.
-        """
-        runs = []
-
+        """List recent canonical runs by state-file modification time."""
         if not self.runs_root.exists():
-            return runs
+            return []
 
-        # Get directories and their modification times
-        candidates = []
-        with os.scandir(self.runs_root) as it:
-            for entry in it:
+        candidates: List[tuple[float, Path]] = []
+        with os.scandir(self.runs_root) as entries:
+            for entry in entries:
                 if entry.is_dir():
-                    # capture mtime and path
-                    # entry.stat() is cached from scandir
                     candidates.append((entry.stat().st_mtime, Path(entry.path)))
+        candidates.sort(key=lambda item: item[0], reverse=True)
 
-        # Sort by mtime descending (newest first)
-        candidates.sort(key=lambda x: x[0], reverse=True)
-
-        # Check for valid runs (run_state.json exists) in sorted order
+        runs: List[Dict[str, Any]] = []
         for _, run_dir in candidates:
             if len(runs) >= limit:
                 break
-
             state_path = run_dir / "run_state.json"
             if not state_path.exists():
                 continue
-
             try:
-                state = json.loads(state_path.read_text(encoding="utf-8"))
+                state = self._synchronize_aliases(
+                    json.loads(state_path.read_text(encoding="utf-8"))
+                )
                 runs.append(
                     {
                         "run_id": state.get("run_id", run_dir.name),
-                        "flow_key": state.get("flow_id", "").split("-")[-1]
-                        if state.get("flow_id")
-                        else None,
+                        "flow_key": state.get("flow_key"),
                         "status": state.get("status"),
-                        "timestamp": state.get("created_at"),
+                        "timestamp": state.get("created_at") or state.get("timestamp"),
                     }
                 )
-            except Exception as e:
-                logger.warning("Failed to load run state %s: %s", run_dir, e)
-
+            except (OSError, json.JSONDecodeError, TypeError) as exc:
+                logger.warning("Failed to load run state %s: %s", run_dir, exc)
         return runs
 
 
-# Global state manager (initialized on first use)
 _state_manager: Optional[RunStateManager] = None
 
 
 def get_state_manager() -> RunStateManager:
-    """Get or create the global state manager."""
+    """Get or create the API adapter for the configured canonical run root."""
     global _state_manager
     if _state_manager is None:
         from swarm.api.server import get_spec_manager

--- a/swarm/runtime/canonical_autopilot.py
+++ b/swarm/runtime/canonical_autopilot.py
@@ -1,7 +1,7 @@
 """Canonical API-facing autopilot controller.
 
 The legacy controller owns useful macro-flow behavior but initialized only an
-in-memory cursor plus a partial run directory.  This subclass preserves that
+in-memory cursor plus a partial run directory. This subclass preserves that
 behavior while routing creation through the constitutional run initializer and
 allowing callers such as issue intake to supply the one run identity.
 """
@@ -9,6 +9,7 @@ allowing callers such as issue intake to supply the one run identity.
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from . import storage
@@ -19,6 +20,28 @@ from .types import RunEvent, RunId, RunSpec, generate_run_id
 
 class CanonicalAutopilotController(AutopilotController):
     """Autopilot whose start boundary creates one complete durable run."""
+
+    def __init__(
+        self,
+        repo_root: Optional[Path] = None,
+        orchestrator: Optional[Any] = None,
+        default_config: Optional[AutopilotConfig] = None,
+    ) -> None:
+        """Bind API autopilot to the server's configured repository root."""
+        if repo_root is None:
+            try:
+                from swarm.api.server import get_spec_manager
+
+                repo_root = get_spec_manager().repo_root
+            except (ImportError, RuntimeError):
+                # Standalone and unit-test use can still rely on the legacy
+                # controller's deterministic repository-root detection.
+                repo_root = None
+        super().__init__(
+            repo_root=repo_root,
+            orchestrator=orchestrator,
+            default_config=default_config,
+        )
 
     def start(
         self,

--- a/swarm/runtime/canonical_autopilot.py
+++ b/swarm/runtime/canonical_autopilot.py
@@ -1,0 +1,108 @@
+"""Canonical API-facing autopilot controller.
+
+The legacy controller owns useful macro-flow behavior but initialized only an
+in-memory cursor plus a partial run directory.  This subclass preserves that
+behavior while routing creation through the constitutional run initializer and
+allowing callers such as issue intake to supply the one run identity.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from . import storage
+from .autopilot import AutopilotConfig, AutopilotController, AutopilotState
+from .run_factory import initialize_run
+from .types import RunEvent, RunId, RunSpec, generate_run_id
+
+
+class CanonicalAutopilotController(AutopilotController):
+    """Autopilot whose start boundary creates one complete durable run."""
+
+    def start(
+        self,
+        issue_ref: Optional[str] = None,
+        flow_keys: Optional[List[str]] = None,
+        profile_id: Optional[str] = None,
+        backend: str = "claude-step-orchestrator",
+        initiator: str = "autopilot",
+        params: Optional[Dict[str, Any]] = None,
+        auto_apply_wisdom: Optional[bool] = None,
+        auto_apply_policy: Optional[str] = None,
+        auto_apply_patch_types: Optional[List[str]] = None,
+        run_id: Optional[RunId] = None,
+    ) -> RunId:
+        """Create a durable autopilot run under a caller-supplied identity."""
+        canonical_run_id = run_id or generate_run_id()
+        flows = list(flow_keys or self._get_sdlc_flows())
+        if not flows:
+            raise ValueError("Autopilot requires at least one flow")
+
+        config = AutopilotConfig(
+            auto_apply_wisdom=(
+                auto_apply_wisdom
+                if auto_apply_wisdom is not None
+                else self._default_config.auto_apply_wisdom
+            ),
+            auto_apply_policy=(
+                auto_apply_policy
+                if auto_apply_policy is not None
+                else self._default_config.auto_apply_policy
+            ),
+            auto_apply_patch_types=list(
+                auto_apply_patch_types
+                if auto_apply_patch_types is not None
+                else self._default_config.auto_apply_patch_types
+            ),
+        )
+
+        spec = RunSpec(
+            flow_keys=flows,
+            profile_id=profile_id,
+            backend=backend,
+            initiator=initiator,
+            params={
+                **(params or {}),
+                "autopilot": True,
+                "issue_ref": issue_ref,
+                "auto_apply_wisdom": config.auto_apply_wisdom,
+                "auto_apply_policy": config.auto_apply_policy,
+            },
+            no_human_mid_flow=True,
+        )
+        state = AutopilotState(
+            run_id=canonical_run_id,
+            spec=spec,
+            config=config,
+            flows_to_execute=flows,
+            current_flow_index=0,
+        )
+
+        runs_dir = self._repo_root / "swarm" / "runs"
+        initialize_run(
+            canonical_run_id,
+            spec,
+            flow_key=flows[0],
+            mode="execute",
+            runs_dir=runs_dir,
+        )
+        self._states[canonical_run_id] = state
+
+        storage.append_event(
+            canonical_run_id,
+            RunEvent(
+                run_id=canonical_run_id,
+                ts=datetime.now(timezone.utc),
+                kind="autopilot_started",
+                flow_key=flows[0],
+                payload={
+                    "flows": flows,
+                    "issue_ref": issue_ref,
+                    "no_human_mid_flow": True,
+                },
+            ),
+            runs_dir,
+        )
+
+        return canonical_run_id

--- a/swarm/runtime/run_factory.py
+++ b/swarm/runtime/run_factory.py
@@ -1,0 +1,135 @@
+"""Canonical run initialization for every Flow Studio entry point.
+
+A run is externally visible only after its durable launch record exists:
+``spec.json``, ``meta.json``, ``run_state.json``, and the initial
+``run_created`` event.  Individual files are atomically replaced by the
+storage layer; this module owns the cross-file fail-closed boundary.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from . import storage
+from .types import (
+    RunEvent,
+    RunId,
+    RunSpec,
+    RunState,
+    RunStatus,
+    RunSummary,
+    SDLCStatus,
+)
+
+
+@dataclass(frozen=True)
+class InitializedRun:
+    """The durable objects created for one run identity."""
+
+    run_id: RunId
+    spec: RunSpec
+    summary: RunSummary
+    state: RunState
+    path: Path
+
+
+def initialize_run(
+    run_id: RunId,
+    spec: RunSpec,
+    *,
+    flow_key: Optional[str] = None,
+    start_step: Optional[str] = None,
+    mode: str = "execute",
+    runs_dir: Path = storage.RUNS_DIR,
+) -> InitializedRun:
+    """Create one complete durable launch record or fail without publishing it.
+
+    The per-run ``spec.json`` is scoped by its containing run directory; the
+    run identity is repeated in metadata, runtime state, and every event where
+    it is semantically part of the record.
+
+    Args:
+        run_id: Stable identity selected by the caller.
+        spec: Execution intent for the run.
+        flow_key: Initial flow. Defaults to the first flow in ``spec``.
+        start_step: Optional initial program-counter node.
+        mode: Requested API mode (execute, preview, or validate).
+        runs_dir: Canonical run root.
+
+    Returns:
+        The initialized durable objects.
+
+    Raises:
+        FileExistsError: A non-empty run directory already owns ``run_id``.
+        ValueError: No initial flow can be derived.
+        RuntimeError: The constitutional journal row could not be persisted.
+    """
+    initial_flow = flow_key or (spec.flow_keys[0] if spec.flow_keys else None)
+    if not initial_flow:
+        raise ValueError("A canonical run requires at least one flow")
+
+    run_path = storage.get_run_path(run_id, runs_dir)
+    if run_path.exists() and any(run_path.iterdir()):
+        raise FileExistsError(f"Run already exists: {run_id}")
+
+    created_new_directory = not run_path.exists()
+    now = datetime.now(timezone.utc)
+    state = RunState(
+        run_id=run_id,
+        flow_key=initial_flow,
+        current_step_id=start_step,
+        status=RunStatus.PENDING.value,
+        timestamp=now,
+    )
+    summary = RunSummary(
+        id=run_id,
+        spec=spec,
+        status=RunStatus.PENDING,
+        sdlc_status=SDLCStatus.UNKNOWN,
+        created_at=now,
+        updated_at=now,
+        path=str(run_path),
+    )
+
+    try:
+        storage.create_run_dir(run_id, runs_dir)
+        storage.write_spec(run_id, spec, runs_dir)
+        storage.write_summary(run_id, summary, runs_dir)
+        storage.write_run_state(run_id, state, runs_dir)
+        storage.append_event(
+            run_id,
+            RunEvent(
+                run_id=run_id,
+                ts=now,
+                kind="run_created",
+                flow_key=initial_flow,
+                payload={
+                    "status": RunStatus.PENDING.value,
+                    "mode": mode,
+                    "backend": spec.backend,
+                    "initiator": spec.initiator,
+                    "flow_keys": list(spec.flow_keys),
+                },
+            ),
+            runs_dir,
+        )
+
+        events = storage.read_events(run_id, runs_dir)
+        if not events or events[0].kind != "run_created" or events[0].run_id != run_id:
+            raise RuntimeError(f"Failed to persist canonical run_created event for {run_id}")
+    except Exception:
+        if created_new_directory and run_path.exists():
+            shutil.rmtree(run_path, ignore_errors=True)
+        raise
+
+    return InitializedRun(
+        run_id=run_id,
+        spec=spec,
+        summary=summary,
+        state=state,
+        path=run_path,
+    )

--- a/tests/test_run_spine_contract.py
+++ b/tests/test_run_spine_contract.py
@@ -1,0 +1,198 @@
+"""Constitutional integration tests for the Flow Studio run spine.
+
+These tests deliberately cross package boundaries. A public execute request must
+create one durable run identity, and transport adapters must preserve canonical
+event meaning instead of inventing parallel state or event contracts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import swarm.api.routes.issue_routes as issue_routes
+import swarm.api.routes.runs_control as runs_control
+import swarm.api.routes.runs_crud as runs_crud
+from swarm.api.routes.events import generate_run_events
+from swarm.api.routes.runs import router as runs_router
+from swarm.api.services.run_state import RunStateManager
+
+
+@pytest.fixture
+def run_api(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Iterator[tuple[TestClient, RunStateManager]]:
+    """Mount the public run API against an isolated durable run directory."""
+    manager = RunStateManager(tmp_path / "runs")
+
+    monkeypatch.setattr(runs_crud, "get_state_manager", lambda: manager)
+    monkeypatch.setattr(runs_control, "get_state_manager", lambda: manager)
+    monkeypatch.setattr(issue_routes, "get_state_manager", lambda: manager)
+
+    app = FastAPI()
+    app.include_router(runs_router, prefix="/api")
+
+    with TestClient(app) as client:
+        yield client, manager
+
+
+def _read_json(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def _record_run_id(record: dict) -> str | None:
+    return record.get("run_id") or record.get("id")
+
+
+def test_execute_start_returns_after_canonical_run_initialization(run_api) -> None:
+    """HTTP 201 in execute mode requires one complete durable launch record."""
+    client, manager = run_api
+
+    response = client.post(
+        "/api/runs",
+        json={"flow_id": "signal", "mode": "execute"},
+    )
+
+    assert response.status_code == 201
+    run_id = response.json()["run_id"]
+    run_dir = manager.runs_root / run_id
+
+    required_files = ("spec.json", "meta.json", "run_state.json", "events.jsonl")
+    missing = [name for name in required_files if not (run_dir / name).is_file()]
+    assert not missing, (
+        "POST /api/runs returned 201 for execute mode without a canonical "
+        f"durable launch record; missing: {missing}"
+    )
+
+    spec = _read_json(run_dir / "spec.json")
+    meta = _read_json(run_dir / "meta.json")
+    state = _read_json(run_dir / "run_state.json")
+    events = _read_jsonl(run_dir / "events.jsonl")
+
+    assert _record_run_id(spec) == run_id
+    assert _record_run_id(meta) == run_id
+    assert _record_run_id(state) == run_id
+
+    assert events, "canonical initialization must append a run_created event"
+    first_event = events[0]
+    assert first_event["run_id"] == run_id
+    assert first_event["kind"] == "run_created"
+    assert {"event_id", "seq", "run_id", "kind"} <= first_event.keys()
+
+
+def test_sse_preserves_runtime_event_kind(tmp_path: Path) -> None:
+    """SSE is a transport projection of RunEvent.kind, not another dialect."""
+    runs_root = tmp_path / "runs"
+    run_id = "run-sse-contract"
+    run_dir = runs_root / run_id
+    run_dir.mkdir(parents=True)
+
+    (run_dir / "run_state.json").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "flow_key": "signal",
+                "status": "running",
+                "current_step_id": "intake",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (run_dir / "events.jsonl").write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "ts": "2026-08-20T00:00:00Z",
+                "kind": "step_start",
+                "flow_key": "signal",
+                "event_id": "evt-step-start-1",
+                "seq": 1,
+                "step_id": "intake",
+                "agent_key": None,
+                "payload": {"step_index": 0},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    async def collect_first_runtime_event() -> tuple[str, str]:
+        stream = generate_run_events(
+            run_id=run_id,
+            runs_root=runs_root,
+            poll_interval=0,
+            heartbeat_interval=3600,
+        )
+        try:
+            connected = await anext(stream)
+            runtime_event = await anext(stream)
+            return connected, runtime_event
+        finally:
+            await stream.aclose()
+
+    connected, runtime_event = asyncio.run(collect_first_runtime_event())
+
+    assert "event: connected\n" in connected
+    assert "event: step:started\n" in runtime_event
+    assert '"kind": "step_start"' in runtime_event
+    assert '"event_id": "evt-step-start-1"' in runtime_event
+
+
+def test_issue_ingestion_reuses_started_autopilot_run_identity(
+    run_api,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue intake and its requested autopilot execution are the same run."""
+    client, manager = run_api
+    canonical_run_id = "run-issue-autopilot-contract"
+
+    class FakeAutopilotController:
+        def __init__(self) -> None:
+            self.start_calls: list[dict] = []
+
+        def start(self, **kwargs) -> str:
+            self.start_calls.append(kwargs)
+            return canonical_run_id
+
+    controller = FakeAutopilotController()
+    monkeypatch.setattr(
+        issue_routes,
+        "_get_autopilot_controller",
+        lambda: controller,
+    )
+
+    response = client.post(
+        "/api/runs/from-issue",
+        json={
+            "title": "Constitutional run identity",
+            "body": "The issue snapshot and execution must share one run ID.",
+            "start_autopilot": True,
+            "flow_keys": ["signal"],
+        },
+    )
+
+    assert response.status_code == 201
+    payload = response.json()
+    assert payload["autopilot_started"] is True
+    assert payload["run_id"] == canonical_run_id
+    assert payload["events_url"] == f"/api/runs/{canonical_run_id}/events"
+
+    snapshot_path = manager.runs_root / canonical_run_id / payload["issue_snapshot_path"]
+    assert snapshot_path.is_file()
+    assert {path.name for path in manager.runs_root.iterdir()} == {canonical_run_id}
+    assert len(controller.start_calls) == 1

--- a/tests/test_run_spine_contract.py
+++ b/tests/test_run_spine_contract.py
@@ -19,7 +19,7 @@ from fastapi.testclient import TestClient
 import swarm.api.routes.issue_routes as issue_routes
 import swarm.api.routes.runs_control as runs_control
 import swarm.api.routes.runs_crud as runs_crud
-from swarm.api.routes.events import generate_run_events
+from swarm.api.routes.events import EventType, generate_run_events, write_event_sync
 from swarm.api.routes.runs import router as runs_router
 from swarm.api.services.run_state import RunStateManager
 
@@ -84,7 +84,10 @@ def test_execute_start_returns_after_canonical_run_initialization(run_api) -> No
     state = _read_json(run_dir / "run_state.json")
     events = _read_jsonl(run_dir / "events.jsonl")
 
-    assert _record_run_id(spec) == run_id
+    # RunSpec remains reusable intent scoped by its containing run directory;
+    # identity is repeated only where it is semantically part of the record.
+    assert spec["flow_keys"] == ["signal"]
+    assert spec["backend"] == "claude-step-orchestrator"
     assert _record_run_id(meta) == run_id
     assert _record_run_id(state) == run_id
 
@@ -153,13 +156,33 @@ def test_sse_preserves_runtime_event_kind(tmp_path: Path) -> None:
     assert '"event_id": "evt-step-start-1"' in runtime_event
 
 
-def test_issue_ingestion_reuses_started_autopilot_run_identity(
+def test_control_event_writer_uses_canonical_journal(run_api) -> None:
+    """Compatibility control writers may translate names, never schemas."""
+    client, manager = run_api
+    response = client.post("/api/runs", json={"flow_id": "signal"})
+    assert response.status_code == 201
+    run_id = response.json()["run_id"]
+
+    write_event_sync(
+        run_id,
+        manager.runs_root,
+        EventType.RUN_STOPPING,
+        {"run_id": run_id, "flow_key": "signal", "reason": "contract_test"},
+    )
+
+    events = _read_jsonl(manager.runs_root / run_id / "events.jsonl")
+    assert events[-1]["kind"] == "run_stopping"
+    assert events[-1]["run_id"] == run_id
+    assert "event" not in events[-1]
+    assert events[-1]["payload"]["reason"] == "contract_test"
+
+
+def test_issue_ingestion_supplies_one_identity_to_autopilot(
     run_api,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Issue intake and its requested autopilot execution are the same run."""
+    """Issue intake selects the ID and autopilot must preserve it."""
     client, manager = run_api
-    canonical_run_id = "run-issue-autopilot-contract"
 
     class FakeAutopilotController:
         def __init__(self) -> None:
@@ -167,14 +190,10 @@ def test_issue_ingestion_reuses_started_autopilot_run_identity(
 
         def start(self, **kwargs) -> str:
             self.start_calls.append(kwargs)
-            return canonical_run_id
+            return kwargs["run_id"]
 
     controller = FakeAutopilotController()
-    monkeypatch.setattr(
-        issue_routes,
-        "_get_autopilot_controller",
-        lambda: controller,
-    )
+    monkeypatch.setattr(issue_routes, "_get_autopilot_controller", lambda: controller)
 
     response = client.post(
         "/api/runs/from-issue",
@@ -189,10 +208,16 @@ def test_issue_ingestion_reuses_started_autopilot_run_identity(
     assert response.status_code == 201
     payload = response.json()
     assert payload["autopilot_started"] is True
-    assert payload["run_id"] == canonical_run_id
-    assert payload["events_url"] == f"/api/runs/{canonical_run_id}/events"
-
-    snapshot_path = manager.runs_root / canonical_run_id / payload["issue_snapshot_path"]
-    assert snapshot_path.is_file()
-    assert {path.name for path in manager.runs_root.iterdir()} == {canonical_run_id}
     assert len(controller.start_calls) == 1
+
+    supplied_run_id = controller.start_calls[0]["run_id"]
+    assert payload["run_id"] == supplied_run_id
+    assert payload["events_url"] == f"/api/runs/{supplied_run_id}/events"
+
+    run_dir = manager.runs_root / supplied_run_id
+    snapshot_path = run_dir / payload["issue_snapshot_path"]
+    assert snapshot_path.is_file()
+    assert {path.name for path in manager.runs_root.iterdir()} == {supplied_run_id}
+    assert {"spec.json", "meta.json", "run_state.json", "events.jsonl"} <= {
+        path.name for path in run_dir.iterdir()
+    }

--- a/tests/test_run_spine_contract.py
+++ b/tests/test_run_spine_contract.py
@@ -44,10 +44,12 @@ def run_api(
 
 
 def _read_json(path: Path) -> dict:
+    """Read one UTF-8 JSON object from ``path``."""
     return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _read_jsonl(path: Path) -> list[dict]:
+    """Read all non-empty JSONL rows from ``path``."""
     return [
         json.loads(line)
         for line in path.read_text(encoding="utf-8").splitlines()
@@ -56,6 +58,7 @@ def _read_jsonl(path: Path) -> list[dict]:
 
 
 def _record_run_id(record: dict) -> str | None:
+    """Return the canonical identity from runtime or summary-shaped data."""
     return record.get("run_id") or record.get("id")
 
 
@@ -96,6 +99,8 @@ def test_execute_start_returns_after_canonical_run_initialization(run_api) -> No
     assert first_event["run_id"] == run_id
     assert first_event["kind"] == "run_created"
     assert {"event_id", "seq", "run_id", "kind"} <= first_event.keys()
+    assert isinstance(first_event["seq"], int) and first_event["seq"] > 0
+    assert isinstance(first_event["event_id"], str) and first_event["event_id"]
 
 
 def test_sse_preserves_runtime_event_kind(tmp_path: Path) -> None:
@@ -135,6 +140,7 @@ def test_sse_preserves_runtime_event_kind(tmp_path: Path) -> None:
     )
 
     async def collect_first_runtime_event() -> tuple[str, str]:
+        """Collect the connection event and first canonical journal event."""
         stream = generate_run_events(
             run_id=run_id,
             runs_root=runs_root,
@@ -185,10 +191,14 @@ def test_issue_ingestion_supplies_one_identity_to_autopilot(
     client, manager = run_api
 
     class FakeAutopilotController:
+        """Record the supplied identity without performing real execution."""
+
         def __init__(self) -> None:
+            """Create an empty invocation ledger."""
             self.start_calls: list[dict] = []
 
         def start(self, **kwargs) -> str:
+            """Return exactly the identity selected by issue intake."""
             self.start_calls.append(kwargs)
             return kwargs["run_id"]
 


### PR DESCRIPTION
# Pull Request

## Selftest Impact

- [x] **No selftest changes** (runtime/API code and focused pytest contracts only)
- [ ] **Selftest config or tests changed**

---

## Description

This PR collapses the first set of competing run authorities onto the runtime contracts already present in the repository.

A public run is now published only after one durable launch record exists:

```text
spec.json
meta.json
run_state.json
events.jsonl (first row: canonical run_created)
```

The runtime `RunState`/`RunEvent` shapes remain authoritative. The HTTP state manager supplies compatibility aliases over `run_state.json` and rereads disk on each request so executor writes cannot be hidden by a stale API cache. SSE maps `RunEvent.kind` to transport names at read time, while compatibility event writers now append typed runtime events instead of a second `{event,timestamp}` dialect.

Issue ingestion now selects one run ID and supplies it to API autopilot. The API-facing autopilot controller initializes that same ID through the canonical run factory, so the issue snapshot, events URL, run state, and execution plan no longer split across visible and hidden runs.

### Deliberate boundary

This PR establishes identity, initialization, and event transport. It does **not** claim that ordinary REST pause/stop/cancel currently signal a live Stepwise worker, nor that the inherited autopilot tick path is healthy. Those are the next enforceable slices after this one merges.

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Swarm config change
- [ ] Test-only change

---

## How Has This Been Tested?

- [x] Focused constitutional integration tests in `tests/test_run_spine_contract.py`
- [x] GitHub Actions swarm unit tests
- [x] GitHub Actions integration tests
- [x] GitHub Actions full dev-check backup
- [x] GitHub Actions UI drift check
- [x] GitHub Actions performance suite
- [ ] Local test execution (connector-only environment; CI is the execution receipt)

The tests prove:

1. `POST /api/runs` returns only after the four-file launch record exists.
2. `run_created` has a non-empty event ID and positive monotonic sequence.
3. SSE preserves canonical event kind and durable event identity.
4. control-event compatibility writers persist the canonical journal schema.
5. issue intake and requested autopilot use one supplied run ID.

---

## Checklist

- [x] Code follows existing Python/FastAPI/runtime conventions
- [x] Self-review completed against current `main`
- [x] Non-obvious authority and compatibility boundaries are documented in code
- [x] Changes generate no TypeScript drift
- [x] Tests prove the repaired cross-package joins
- [x] No downstream module publication is required
- [x] No agent, flow, adapter, or generated configuration changed

---

## Selftest Status

**Status**: HEALTHY

No degraded-mode merge is requested.

---

## Related Issues

Relates to EffortlessMetrics/flow-studio#20
Relates to EffortlessMetrics/flow-studio#22

---

## Additional Context

Review base: `main@7d7c4af749ec7daeeb3b6e3631aa57454b6b296f`.

This is the first authority-collapse PR. The next slice will make one public executor entry point runnable and fail closed: replace the missing `storage.init_run` call, remove private `_execute_stepwise` backend access, and separate explicit deterministic-test execution from real-provider backends.